### PR TITLE
[ENH] SubsetResampling issue #5.

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -233,6 +233,7 @@ Classes
 
     optimization.BaseComposition
     optimization.StackingOptimization
+    optimization.SubsetResampling
 
 .. _prior_ref:
 

--- a/src/skfolio/optimization/ensemble/__init__.py
+++ b/src/skfolio/optimization/ensemble/__init__.py
@@ -1,6 +1,7 @@
+from skfolio.optimization.ensemble._bagging import SubsetResampling
 from skfolio.optimization.ensemble._stacking import (
     BaseComposition,
     StackingOptimization,
 )
 
-__all__ = ["BaseComposition", "StackingOptimization"]
+__all__ = ["BaseComposition", "StackingOptimization", "SubsetResampling"]

--- a/src/skfolio/optimization/ensemble/_bagging.py
+++ b/src/skfolio/optimization/ensemble/_bagging.py
@@ -1,0 +1,125 @@
+import numpy as np
+from sklearn.ensemble import BaggingRegressor
+
+from skfolio.optimization._base import BaseOptimization
+from skfolio.optimization.ensemble._base import BaseComposition
+
+
+class BaseComposedBaggingRegressor(BaggingRegressor, BaseComposition):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+class SubsetResampling(BaseOptimization, BaseComposedBaggingRegressor):
+    """
+    A bagging ensemble that performs subset resampling with base optimization models.
+
+    This class extends the `BaggingRegressor` and performs resampling with a set of base optimization models.
+    The ensemble uses a specified base optimization model (`estimator`) and creates an ensemble of models by
+    training on randomly sampled subsets of features.
+    The resampling is performed without replacement.
+
+    Parameters:
+    -----------
+    estimator : BaseOptimization, optional
+        The base optimization model to use for building the ensemble.
+        If not provided, the base model is set to None.
+
+    n_estimators : int, optional (default=10)
+        The number of base optimization models in the ensemble.
+
+    max_features : float, optional (default=0.7)
+        The fraction of features to randomly sample for each base optimization model.
+        When the number of features is large decrease the max_features to a smaller percentage
+        in order to let optimization methods run faster.
+
+    warm_start : bool, optional (default=False)
+        If True, reuse the solution of the previous call to fit as an initialization.
+
+    n_jobs : int or None, optional (default=None)
+        The number of jobs to run in parallel for fitting and prediction.
+        None means 1 unless in a joblib.parallel_backend context.
+
+    random_state : int, RandomState instance, or None, optional (default=None)
+        Controls the random resampling of features.
+        Pass an int for reproducible results across multiple function calls.
+
+    verbose : int, optional (default=0)
+        Controls the verbosity when fitting and predicting.
+
+    portfolio_params : dict or None, optional (default=None)
+        Additional parameters to pass to the base optimization model.
+
+    Attributes:
+    ------------
+    estimators_ : list of BaseOptimization
+        The fitted base optimization models in the ensemble.
+
+    named_estimators_ : dict of str to BaseOptimization
+        The named fitted base optimization models in the ensemble.
+    weights_ : ndarray of shape (n_features,)
+        The average weights assigned to each feature across all base optimization models.
+
+    n_features_in_ : int
+        Number of assets seen during `fit`.
+
+    feature_names_in_ : ndarray of shape (`n_features_in_`,)
+        Names of assets seen during `fit`. Defined only when `X`
+        has assets names that are all strings.
+
+    Methods:
+    ---------
+    fit(X, y=None, sample_weight=None):
+        Fit the ensemble to the input data. Overrides the base class method to perform subset resampling.
+
+    Notes:
+    ------
+    This class inherits from `BaggingRegressor` and utilizes the subset resampling technique for building an ensemble
+    of base optimization models.
+    The resampling is performed without replacement, and the average weights of features
+    across all base optimization models are computed and stored in the `weights_` attribute.
+    """
+
+    estimators_: list[BaseOptimization]
+    named_estimators_: dict[str, BaseOptimization]
+
+    def __init__(
+        self,
+        estimator: BaseOptimization = None,
+        n_estimators: int = 10,
+        max_features: float = 0.7,
+        warm_start: bool = False,
+        n_jobs: int | None = None,
+        random_state=None,
+        verbose=0,
+        portfolio_params: dict | None = None,
+    ):
+        super(BaseComposedBaggingRegressor, self).__init__(
+            estimator=estimator,
+            n_estimators=n_estimators,
+            max_samples=1.0,
+            max_features=max_features,
+            bootstrap=False,
+            bootstrap_features=False,
+            oob_score=False,
+            warm_start=warm_start,
+            random_state=random_state,
+            verbose=verbose,
+            n_jobs=n_jobs,
+        )
+        self.portfolio_params = portfolio_params
+
+    def fit(self, X, y=None, sample_weight=None) -> "SubsetResampling":
+        super(BaseComposedBaggingRegressor, self).fit(
+            X, y=np.ones(X.shape[0]), sample_weight=sample_weight
+        )
+        inner_weights = np.zeros(X.shape[1])
+        # important to collect the indices at which the individual estimator weights refer to
+        for estimator, features_indices in zip(
+            self.estimators_, self.estimators_features_, strict=True
+        ):
+            inner_weights[features_indices] += estimator.weights_
+
+        np.divide(inner_weights, self.n_estimators, out=inner_weights)
+        self.weights_ = inner_weights
+        return self

--- a/tests/test_optimization/test_ensemble/test_subsetresampling.py
+++ b/tests/test_optimization/test_ensemble/test_subsetresampling.py
@@ -1,0 +1,16 @@
+import pytest
+from skfolio import RiskMeasure
+from skfolio.optimization import MeanRisk
+from skfolio.optimization.ensemble._bagging import SubsetResampling
+from .test_stacking import X, y, X_y
+
+
+def test_subsetresampling(X, y):
+    portfolio = MeanRisk(risk_measure=RiskMeasure.VARIANCE)
+    model = SubsetResampling(estimator=portfolio, n_estimators=10, max_features=0.5, n_jobs=-1,
+                             random_state=0)
+    model.fit(X, y)
+
+    assert hasattr(model, "weights_"), "Model must have the weights_ attribute of fitted portfolios"
+    assert model.weights_.shape[0] == X.shape[1], ("Model must have as many weights as the number "
+                                                   "of assets ")


### PR DESCRIPTION
#### Reference Issues/PRs
Added SubsetResampling estimator for bagging on features of a general portfolio estimator as discussed in discussion #5 

#### What does this implement/fix? Explain your changes.
A new estimator called SubsetResampling method as discussed in this blog post:

https://blog.thinknewfound.com/2018/07/machine-learning-subset-resampling-and-portfolio-optimization

#### Does your contribution introduce a new dependency? If yes, which one?
No.

#### What should a reviewer concentrate their feedback on?
Checking that the newly written estimator complies with all the properties of a proper portfolio estimator.

#### Did you add any tests for the change?
I added a test_subsetresampling under a new section _bagging in the proper `test/test_optimization/test_ensemble/test_subsetresampling.py`.
The test checks everything works with 10 independent features subsets using the minimum variance portfolio.

#### Any other comments?
Authors of the subset resampling method suggest to set max_features=n^0.8 where n in the total number of assets, this has not been added in the class documentation.

#### PR checklist

##### For all contributions

- [ ] I've added myself to the [list of contributors](https://github.com/skfolio/skfolio/blob/main/CONTRIBUTORS.md)
  How to: add yourself to the [all-contributors file](https://github.com/skfolio/skfolio/blob/main/.all-contributorsrc) in the `skfolio` root directory (not the `CONTRIBUTORS.md`). 
- [ ] Optionally, I've added myself and possibly others to the [CODEOWNERS](https://github.com/skfolio/skfolio/blob/main/CODEOWNERS) file - do this if you want to become the owner or maintainer of an estimator you added.

##### For new estimators
- I've added the estimator to the API reference in `docs/api.rst`: ✅
- I've added one or more illustrative usage examples to the docstring and the `examples` section. ❌
