### PR TITLE
chore: fix pip install in contributing md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ Ready to contribute? Here's how to set yourself up for local development.
 3. Install the project in development mode with the tests and linting dependencies:
 
    ```shell
-   $ pip install --editable .[tests]
+   $ pip install --editable '.[tests]'
    ```
 
 4. Create a branch for local development:


### PR DESCRIPTION
`pip install --editable .[tests]` gives me: `no matches found: .[tests]`