### PR TITLE
[DOC] Type Hint Fixing.

### DIFF
--- a/src/skfolio/optimization/cluster/hierarchical/_base.py
+++ b/src/skfolio/optimization/cluster/hierarchical/_base.py
@@ -8,6 +8,7 @@
 # scikit-learn, Copyright (c) 2007-2010 David Cournapeau, Fabian Pedregosa, Olivier
 
 from abc import ABC, abstractmethod
+from typing import Any
 
 import numpy as np
 import numpy.typing as npt
@@ -235,7 +236,7 @@ class BaseHierarchicalOptimization(BaseOptimization, ABC):
         self,
         value: float | dict | np.ndarray | list,
         n_assets: int,
-        fill_value: any,
+        fill_value: Any,
         name: str,
     ) -> np.ndarray:
         """Convert input to cleaned 1D array
@@ -250,7 +251,7 @@ class BaseHierarchicalOptimization(BaseOptimization, ABC):
         n_assets : int
             Number of assets. Used to verify the shape of the converted array.
 
-        fill_value : any
+        fill_value : Any
             When `items` is a dictionary, elements that are not in `asset_names` are
             filled with `fill_value` in the converted array.
 

--- a/src/skfolio/optimization/convex/_base.py
+++ b/src/skfolio/optimization/convex/_base.py
@@ -9,6 +9,7 @@
 import warnings
 from abc import ABC, abstractmethod
 from enum import auto
+from typing import Any
 
 import cvxpy as cp
 import cvxpy.constraints.constraint as cpc
@@ -575,7 +576,7 @@ class ConvexOptimization(BaseOptimization, ABC):
         self,
         value: float | dict | npt.ArrayLike | None,
         n_assets: int,
-        fill_value: any,
+        fill_value: Any,
         name: str,
     ) -> float | np.ndarray:
         """Convert input to cleaned float or ndarray.
@@ -588,7 +589,7 @@ class ConvexOptimization(BaseOptimization, ABC):
         n_assets : int
             Number of assets. Used to verify the shape of the converted array.
 
-        fill_value : any
+        fill_value : Any
             When `items` is a dictionary, elements that are not in `asset_names` are
             filled with `fill_value` in the converted array.
 

--- a/src/skfolio/population/_population.py
+++ b/src/skfolio/population/_population.py
@@ -7,6 +7,7 @@ A population is a collection of portfolios.
 # License: BSD 3 clause
 
 import inspect
+from typing import Any
 
 import numpy as np
 import pandas as pd
@@ -76,12 +77,12 @@ class Population(list):
         else:
             super().extend(self._validate_item(item) for item in other)
 
-    def set_portfolio_params(self, **params: any) -> "Population":
+    def set_portfolio_params(self, **params: Any) -> "Population":
         """Set the parameters of all the portfolios.
 
         Parameters
         ----------
-        **params : any
+        **params : Any
             Portfolio parameters.
 
         Returns

--- a/src/skfolio/prior/_factor_model.py
+++ b/src/skfolio/prior/_factor_model.py
@@ -9,6 +9,7 @@
 # Grisel Licensed under BSD 3 clause.
 
 from abc import ABC, abstractmethod
+from typing import Any
 
 import numpy as np
 import numpy.typing as npt
@@ -196,7 +197,7 @@ class FactorModel(BasePrior):
         self.max_iteration = max_iteration
 
     # noinspection PyMethodOverriding, PyPep8Naming
-    def fit(self, X: npt.ArrayLike, y: any):
+    def fit(self, X: npt.ArrayLike, y: Any):
         """Fit the Factor Model estimator.
 
         Parameters

--- a/src/skfolio/utils/tools.py
+++ b/src/skfolio/utils/tools.py
@@ -10,6 +10,7 @@
 from collections.abc import Callable, Iterator
 from enum import Enum
 from functools import wraps
+from typing import Any
 
 import numpy as np
 import numpy.typing as npt
@@ -41,7 +42,7 @@ class AutoEnum(str, Enum):
 
     @staticmethod
     def _generate_next_value_(
-        name: str, start: int, count: int, last_values: any
+        name: str, start: int, count: int, last_values: Any
     ) -> str:
         """Overriding `auto()`"""
         return name.lower()
@@ -179,7 +180,7 @@ def args_names(func: object) -> list[str]:
 
 
 def check_estimator(
-    estimator: skb.BaseEstimator | None, default: skb.BaseEstimator, check_type: any
+    estimator: skb.BaseEstimator | None, default: skb.BaseEstimator, check_type: Any
 ):
     """Check the estimator type and returns its cloned version it provided, otherwise
      return the default estimator.
@@ -192,7 +193,7 @@ def check_estimator(
     default : BaseEstimator
         Default estimator to return when `estimator` is `None`.
 
-    check_type : any
+    check_type : Any
         Expected type of the estimator to check against.
 
     Returns
@@ -211,7 +212,7 @@ def check_estimator(
 def input_to_array(
     items: dict | npt.ArrayLike,
     n_assets: int,
-    fill_value: any,
+    fill_value: Any,
     dim: int,
     assets_names: np.ndarray | None,
     name: str,
@@ -228,7 +229,7 @@ def input_to_array(
         Expected number of assets.
         Used to verify the shape of the converted array.
 
-    fill_value : any
+    fill_value : Any
         When `items` is a dictionary, elements that are not in `asset_names` are filled
         with `fill_value` in the converted array.
 
@@ -424,7 +425,7 @@ def safe_split(
 
 
 def fit_single_estimator(
-    estimator: any,
+    estimator: Any,
     X: npt.ArrayLike,
     y: npt.ArrayLike | None = None,
     indices: np.ndarray | None = None,
@@ -463,7 +464,7 @@ def fit_single_estimator(
 
 
 def fit_and_predict(
-    estimator: any,
+    estimator: Any,
     X: npt.ArrayLike,
     y: npt.ArrayLike | None,
     train: np.ndarray,


### PR DESCRIPTION
<!--
Welcome to skfolio, and thanks for contributing!
-->

#### Reference Issues/PRs

Fixes #40 


#### What does this implement/fix? Explain your changes.
previously `any` the python built-in was used  instead of `typing.Any`.
fixed all occurrences.