### PR TITLE
[BUG] Risk Free Rate

### DIFF
--- a/src/skfolio/optimization/_base.py
+++ b/src/skfolio/optimization/_base.py
@@ -29,8 +29,8 @@ class BaseOptimization(skb.BaseEstimator, ABC):
     portfolio_params :  dict, optional
         Portfolio parameters passed to the portfolio evaluated by the `predict` and
         `score` methods. If not provided, the `name`, `transaction_costs`,
-        `management_fees` and `previous_weights` are copied from the optimization
-        model and systematically passed to the portfolio.
+        `management_fees`, `previous_weights` and `risk_free_rate` are copied from the
+        optimization model and passed to the portfolio.
 
     Attributes
     ----------
@@ -84,7 +84,12 @@ class BaseOptimization(skb.BaseEstimator, ABC):
             ptf_kwargs = self.portfolio_params.copy()
 
         # Set the default portfolio parameters equal to the optimization parameters
-        for param in ["transaction_costs", "management_fees", "previous_weights"]:
+        for param in [
+            "transaction_costs",
+            "management_fees",
+            "previous_weights",
+            "risk_free_rate",
+        ]:
             if param not in ptf_kwargs and hasattr(self, param):
                 ptf_kwargs[param] = getattr(self, param)
 

--- a/src/skfolio/optimization/cluster/hierarchical/_base.py
+++ b/src/skfolio/optimization/cluster/hierarchical/_base.py
@@ -184,8 +184,8 @@ class BaseHierarchicalOptimization(BaseOptimization, ABC):
     portfolio_params :  dict, optional
         Portfolio parameters passed to the portfolio evaluated by the `predict` and
         `score` methods. If not provided, the `name`, `transaction_costs`,
-        `management_fees` and `previous_weights` are copied from the optimization
-        model and systematically passed to the portfolio.
+        `management_fees`, `previous_weights` and `risk_free_rate` are copied from the
+        optimization model and passed to the portfolio.
 
     Attributes
     ----------

--- a/src/skfolio/optimization/cluster/hierarchical/_herc.py
+++ b/src/skfolio/optimization/cluster/hierarchical/_herc.py
@@ -204,8 +204,8 @@ class HierarchicalEqualRiskContribution(BaseHierarchicalOptimization):
     portfolio_params :  dict, optional
         Portfolio parameters passed to the portfolio evaluated by the `predict` and
         `score` methods. If not provided, the `name`, `transaction_costs`,
-        `management_fees` and `previous_weights` are copied from the optimization
-        model and systematically passed to the portfolio.
+        `management_fees`, `previous_weights` and `risk_free_rate` are copied from the
+        optimization model and passed to the portfolio.
 
     Attributes
     ----------

--- a/src/skfolio/optimization/cluster/hierarchical/_hrp.py
+++ b/src/skfolio/optimization/cluster/hierarchical/_hrp.py
@@ -204,8 +204,8 @@ class HierarchicalRiskParity(BaseHierarchicalOptimization):
     portfolio_params :  dict, optional
         Portfolio parameters passed to the portfolio evaluated by the `predict` and
         `score` methods. If not provided, the `name`, `transaction_costs`,
-        `management_fees` and `previous_weights` are copied from the optimization
-        model and systematically passed to the portfolio.
+        `management_fees`, `previous_weights` and `risk_free_rate` are copied from the
+        optimization model and passed to the portfolio.
 
     Attributes
     ----------

--- a/src/skfolio/optimization/convex/_base.py
+++ b/src/skfolio/optimization/convex/_base.py
@@ -404,8 +404,8 @@ class ConvexOptimization(BaseOptimization, ABC):
     portfolio_params :  dict, optional
         Portfolio parameters passed to the portfolio evaluated by the `predict` and
         `score` methods. If not provided, the `name`, `transaction_costs`,
-        `management_fees` and `previous_weights` are copied from the optimization
-        model and systematically passed to the portfolio.
+        `management_fees`, `previous_weights` and `risk_free_rate` are copied from the
+        optimization model and passed to the portfolio.
 
     Attributes
     ----------

--- a/src/skfolio/optimization/convex/_distributionally_robust.py
+++ b/src/skfolio/optimization/convex/_distributionally_robust.py
@@ -208,8 +208,8 @@ class DistributionallyRobustCVaR(ConvexOptimization):
     portfolio_params :  dict, optional
         Portfolio parameters passed to the portfolio evaluated by the `predict` and
         `score` methods. If not provided, the `name`, `transaction_costs`,
-        `management_fees` and `previous_weights` are copied from the optimization
-        model and systematically passed to the portfolio.
+        `management_fees`, `previous_weights` and `risk_free_rate` are copied from the
+        optimization model and passed to the portfolio.
 
     Attributes
     ----------

--- a/src/skfolio/optimization/convex/_maximum_diversification.py
+++ b/src/skfolio/optimization/convex/_maximum_diversification.py
@@ -303,8 +303,8 @@ class MaximumDiversification(MeanRisk):
     portfolio_params :  dict, optional
         Portfolio parameters passed to the portfolio evaluated by the `predict` and
         `score` methods. If not provided, the `name`, `transaction_costs`,
-        `management_fees` and `previous_weights` are copied from the optimization
-        model and systematically passed to the portfolio.
+        `management_fees`, `previous_weights` and `risk_free_rate` are copied from the
+        optimization model and passed to the portfolio.
 
     Attributes
     ----------

--- a/src/skfolio/optimization/convex/_mean_risk.py
+++ b/src/skfolio/optimization/convex/_mean_risk.py
@@ -510,8 +510,8 @@ class MeanRisk(ConvexOptimization):
     portfolio_params :  dict, optional
         Portfolio parameters passed to the portfolio evaluated by the `predict` and
         `score` methods. If not provided, the `name`, `transaction_costs`,
-        `management_fees` and `previous_weights` are copied from the optimization
-        model and systematically passed to the portfolio.
+        `management_fees`, `previous_weights` and `risk_free_rate` are copied from the 
+        optimization model and passed to the portfolio.
 
     Attributes
     ----------

--- a/src/skfolio/optimization/convex/_risk_budgeting.py
+++ b/src/skfolio/optimization/convex/_risk_budgeting.py
@@ -340,8 +340,8 @@ class RiskBudgeting(ConvexOptimization):
     portfolio_params :  dict, optional
         Portfolio parameters passed to the portfolio evaluated by the `predict` and
         `score` methods. If not provided, the `name`, `transaction_costs`,
-        `management_fees` and `previous_weights` are copied from the optimization
-        model and systematically passed to the portfolio.
+        `management_fees`, `previous_weights` and `risk_free_rate` are copied from the 
+        optimization model and passed to the portfolio.
 
     Attributes
     ----------

--- a/src/skfolio/optimization/naive/_naive.py
+++ b/src/skfolio/optimization/naive/_naive.py
@@ -31,8 +31,8 @@ class InverseVolatility(BaseOptimization):
     portfolio_params :  dict, optional
         Portfolio parameters passed to the portfolio evaluated by the `predict` and
         `score` methods. If not provided, the `name`, `transaction_costs`,
-        `management_fees` and `previous_weights` are copied from the optimization
-        model and systematically passed to the portfolio.
+        `management_fees`, `previous_weights` and `risk_free_rate` are copied from the
+        optimization model and passed to the portfolio.
 
     Attributes
     ----------
@@ -95,8 +95,8 @@ class EqualWeighted(BaseOptimization):
     portfolio_params :  dict, optional
         Portfolio parameters passed to the portfolio evaluated by the `predict` and
         `score` methods. If not provided, the `name`, `transaction_costs`,
-        `management_fees` and `previous_weights` are copied from the optimization
-        model and systematically passed to the portfolio.
+        `management_fees`, `previous_weights` and `risk_free_rate` are copied from the
+        optimization model and passed to the portfolio.
 
     Attributes
     ----------
@@ -139,8 +139,8 @@ class Random(BaseOptimization):
     portfolio_params :  dict, optional
         Portfolio parameters passed to the portfolio evaluated by the `predict` and
         `score` methods. If not provided, the `name`, `transaction_costs`,
-        `management_fees` and `previous_weights` are copied from the optimization
-        model and systematically passed to the portfolio.
+        `management_fees`, `previous_weights` and `risk_free_rate` are copied from the
+        optimization model and passed to the portfolio.
 
     Attributes
     ----------

--- a/src/skfolio/population/_population.py
+++ b/src/skfolio/population/_population.py
@@ -16,7 +16,7 @@ import plotly.graph_objects as go
 import scipy.interpolate as sci
 
 import skfolio.typing as skt
-from skfolio.portfolio import BasePortfolio, MultiPeriodPortfolio, Portfolio
+from skfolio.portfolio import BasePortfolio, MultiPeriodPortfolio
 from skfolio.utils.sorting import non_denominated_sort
 from skfolio.utils.tools import deduplicate_names
 
@@ -31,14 +31,14 @@ class Population(list):
 
     Parameters
     ----------
-    iterable : list[Portfolio | MultiPeriodPortfolio]
+    iterable : list[BasePortfolio]
         The list of portfolios. Each item can be of type
         :class:`~skfolio.portfolio.Portfolio` and/or
         :class:`~skfolio.portfolio.MultiPeriodPortfolio`.
         Empty list are accepted.
     """
 
-    def __init__(self, iterable: list[Portfolio | MultiPeriodPortfolio]) -> None:
+    def __init__(self, iterable: list[BasePortfolio]) -> None:
         super().__init__(self._validate_item(item) for item in iterable)
 
     def __repr__(self) -> str:
@@ -46,31 +46,31 @@ class Population(list):
 
     def __getitem__(
         self, indices: int | list[int] | slice
-    ) -> "Portfolio | MultiPeriodPortfolio|Population":
+    ) -> "BasePortfolio | Population":
         item = super().__getitem__(indices)
         if isinstance(item, list):
             return self.__class__(item)
         return item
 
-    def __setitem__(self, index: int, item: Portfolio | MultiPeriodPortfolio) -> None:
+    def __setitem__(self, index: int, item: BasePortfolio) -> None:
         super().__setitem__(index, self._validate_item(item))
 
-    def __add__(self, other: Portfolio | MultiPeriodPortfolio) -> "Population":
+    def __add__(self, other: BasePortfolio) -> "Population":
         if not isinstance(other, Population):
             raise TypeError(
                 f"Cannot add a Population with an object of type {type(other)}"
             )
         return self.__class__(super().__add__(other))
 
-    def insert(self, index, item: Portfolio | MultiPeriodPortfolio) -> None:
+    def insert(self, index, item: BasePortfolio) -> None:
         """Insert portfolio before index."""
         super().insert(index, self._validate_item(item))
 
-    def append(self, item: Portfolio | MultiPeriodPortfolio) -> None:
+    def append(self, item: BasePortfolio) -> None:
         """Append portfolio to the end of the population list."""
         super().append(self._validate_item(item))
 
-    def extend(self, other: Portfolio | MultiPeriodPortfolio) -> None:
+    def extend(self, other: BasePortfolio) -> None:
         """Extend population list by appending elements from the iterable."""
         if isinstance(other, type(self)):
             super().extend(other)
@@ -112,13 +112,14 @@ class Population(list):
 
     @staticmethod
     def _validate_item(
-        item: Portfolio | MultiPeriodPortfolio,
-    ) -> Portfolio | MultiPeriodPortfolio:
+        item: BasePortfolio,
+    ) -> BasePortfolio:
         """Validate that items are of type Portfolio or MultiPeriodPortfolio."""
-        if isinstance(item, Portfolio | MultiPeriodPortfolio):
+        if isinstance(item, BasePortfolio):
             return item
         raise TypeError(
-            "Population only accept items of type Portfolio and MultiPeriodPortfolio"
+            "Population only accept items that inherit from BasePortfolio such as "
+            "Portfolio or MultiPeriodPortfolio"
             f", got {type(item).__name__}"
         )
 
@@ -325,7 +326,7 @@ class Population(list):
         q: float,
         names: skt.Names | None = None,
         tags: skt.Tags | None = None,
-    ) -> Portfolio | MultiPeriodPortfolio:
+    ) -> BasePortfolio:
         """Returns the portfolio corresponding to the `q` quantile for a given portfolio
         measure.
 
@@ -345,7 +346,7 @@ class Population(list):
 
         Returns
         -------
-        values : Portfolio | MultiPeriodPortfolio
+        values : BasePortfolio
            Portfolio corresponding to the `q` quantile for the measure.
         """
         if not 0 <= q <= 1:
@@ -361,7 +362,7 @@ class Population(list):
         measure: skt.Measure,
         names: skt.Names | None = None,
         tags: skt.Tags | None = None,
-    ) -> Portfolio | MultiPeriodPortfolio:
+    ) -> BasePortfolio:
         """Returns the portfolio with the minimum measure.
 
         Parameters
@@ -377,7 +378,7 @@ class Population(list):
 
         Returns
         -------
-        values : Portfolio | MultiPeriodPortfolio
+        values : BasePortfolio
             The portfolio with minimum measure.
         """
         return self.quantile(measure=measure, q=0, names=names, tags=tags)
@@ -387,7 +388,7 @@ class Population(list):
         measure: skt.Measure,
         names: skt.Names | None = None,
         tags: skt.Tags | None = None,
-    ) -> Portfolio | MultiPeriodPortfolio:
+    ) -> BasePortfolio:
         """Returns the portfolio with the maximum measure.
 
         Parameters
@@ -403,7 +404,7 @@ class Population(list):
 
         Returns
         -------
-        values : Portfolio | MultiPeriodPortfolio
+        values : BasePortfolio
             The portfolio with maximum measure.
         """
         return self.quantile(measure=measure, q=1, names=names, tags=tags)

--- a/tests/test_optimization/test_naive/test_naive.py
+++ b/tests/test_optimization/test_naive/test_naive.py
@@ -12,9 +12,9 @@ from skfolio.prior import FactorModel
 @pytest.fixture(scope="module")
 def X_y():
     prices = load_sp500_dataset()
-    prices = prices.loc[dt.date(2014, 1, 1) :]
+    prices = prices.loc[dt.date(2014, 1, 1):]
     factor_prices = load_factors_dataset()
-    factor_prices = factor_prices.loc[dt.date(2014, 1, 1) :]
+    factor_prices = factor_prices.loc[dt.date(2014, 1, 1):]
     X, y = prices_to_returns(X=prices, y=factor_prices)
     return X, y
 


### PR DESCRIPTION
<!--
Welcome to skfolio, and thanks for contributing!
-->

#### Reference Issues/PRs
Fixes #49



#### What does this implement/fix? Explain your changes.
The risk_free_rate of estimators like MeanRisk is only used for the optimization that involves risk measures that are a function of risk free rates like the Sharpe Ratio. For improved usability, optimization parameters that are also found in Portfolio parameters are automatically passed to the predicted Portfolio unless already provided by portfolio_params (this includes transaction_costs, management_fees and previous_weights). I'll add the risk free rate to that list.

#### Does your contribution introduce a new dependency? If yes, which one?

No

