### PR TITLE
[BUG] feat(prices_to_returns): Add index intersect param

### DIFF
--- a/src/skfolio/preprocessing/_returns.py
+++ b/src/skfolio/preprocessing/_returns.py
@@ -14,7 +14,7 @@ def prices_to_returns(
     log_returns: bool = False,
     nan_threshold: float = 1,
     join: str = "outer",
-    index_intersect: bool = True,
+    drop_inceptions_nan: bool = True,
 ) -> pd.DataFrame | tuple[pd.DataFrame, pd.DataFrame]:
     r"""Transforms a DataFrame of prices to linear or logarithmic returns.
 
@@ -108,7 +108,7 @@ def prices_to_returns(
     df.dropna(axis=1, how="all", inplace=True)
 
     # returns
-    all_returns = df.pct_change().dropna(how="any" if index_intersect else "all")
+    all_returns = df.pct_change().dropna(how="any" if drop_inceptions_nan else "all")
     if log_returns:
         all_returns = np.log1p(all_returns)
 

--- a/src/skfolio/preprocessing/_returns.py
+++ b/src/skfolio/preprocessing/_returns.py
@@ -61,8 +61,8 @@ def prices_to_returns(
         Drop observations (rows) that have a percentage of missing assets prices above
         this threshold. The default (`1.0`) is to keep all the observations.
 
-    index_intersect : bool, default=True
-        Use the intersection of the index to determine when the dataframe index begins.
+    drop_inceptions_nan : bool, default=True
+        If this is set to True,  observations at the beginning are dropped if any of the asset values are missing, otherwise we keep the NaNs. This is useful when you work with a large universe of assets with different inception dates coupled with a pre-selection Transformer.
 
     Returns
     -------

--- a/src/skfolio/preprocessing/_returns.py
+++ b/src/skfolio/preprocessing/_returns.py
@@ -14,6 +14,7 @@ def prices_to_returns(
     log_returns: bool = False,
     nan_threshold: float = 1,
     join: str = "outer",
+    index_intersect: bool = True,
 ) -> pd.DataFrame | tuple[pd.DataFrame, pd.DataFrame]:
     r"""Transforms a DataFrame of prices to linear or logarithmic returns.
 
@@ -60,6 +61,9 @@ def prices_to_returns(
         Drop observations (rows) that have a percentage of missing assets prices above
         this threshold. The default (`1.0`) is to keep all the observations.
 
+    index_intersect : bool, default=True
+        Use the intersection of the index to determine when the dataframe index begins.
+
     Returns
     -------
     X : DataFrame
@@ -104,7 +108,7 @@ def prices_to_returns(
     df.dropna(axis=1, how="all", inplace=True)
 
     # returns
-    all_returns = df.pct_change().dropna()
+    all_returns = df.pct_change().dropna(how="any" if index_intersect else "all")
     if log_returns:
         all_returns = np.log1p(all_returns)
 

--- a/tests/test_preprocessing/test_returns.py
+++ b/tests/test_preprocessing/test_returns.py
@@ -39,6 +39,6 @@ def test_returns(prices, factor_prices):
     assert np.all(X.index == y.index)
 
     # Test index_intersect by making the first column mostly 0's
-    prices[prices.columns.values[0]].iloc[:-10] = 0.0
+    prices.loc[:prices.index[-10], "AAPL"] = 0.0
     X = prices_to_returns(X=prices, index_intersect=False)
     assert X.shape[0] < prices.shape[0] - 1

--- a/tests/test_preprocessing/test_returns.py
+++ b/tests/test_preprocessing/test_returns.py
@@ -40,5 +40,5 @@ def test_returns(prices, factor_prices):
 
     # Test index_intersect by making the first column mostly 0's
     prices.loc[:prices.index[-10], "AAPL"] = 0.0
-    X = prices_to_returns(X=prices, index_intersect=False)
+    X = prices_to_returns(X=prices, drop_inceptions_nan=False)
     assert X.shape[0] < prices.shape[0] - 1

--- a/tests/test_preprocessing/test_returns.py
+++ b/tests/test_preprocessing/test_returns.py
@@ -37,3 +37,8 @@ def test_returns(prices, factor_prices):
     assert np.all(X.columns == prices.columns)
     assert np.all(y.columns == factor_prices.columns)
     assert np.all(X.index == y.index)
+
+    # Test index_intersect by making the first column mostly 0's
+    prices[prices.columns.values[0]].iloc[:-10] = 0.0
+    X = prices_to_returns(X=prices, index_intersect=False)
+    assert X.shape[0] < prices.shape[0] - 1


### PR DESCRIPTION
* Add a parameter allow index intersection to be chosen by the caller.
* This allows the dropna call to either use all or any.
* Functionally this determines whether the start of the index is at the beginning of the shortest price index (any) or the beginning of the longest price index (all)

#### Reference Issues/PRs

Fixes #55 

#### What does this implement/fix? Explain your changes.

Allows the user to choose whether to dropna's using `any` or `all` to preserve the full time index.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

Whether this fix conforms to the discussion in the issue.

#### Did you add any tests for the change?

I extended the `test_returns` test to check for this.

#### Any other comments?

The original behaviour should be unchanged.

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x ] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.
- [ ] Optionally, I've added myself and possibly others to the [CODEOWNERS](https://github.com/skfolio/skfolio/blob/main/CODEOWNERS) file - do this if you want to become the owner or maintainer of an estimator you added. -- File does not exist

##### For new estimators
- [ ] I've added the estimator to the API reference in `docs/api.rst`.
- [ ] I've added one or more illustrative usage examples to the docstring and the `examples` section.

-- No new estimators added.
