### PR TITLE
[BUG] `linear_constraints` supports for equality strings

### DIFF
--- a/examples/1_mean_risk/plot_5_weight_constraints.py
+++ b/examples/1_mean_risk/plot_5_weight_constraints.py
@@ -180,7 +180,7 @@ model.weights_
 #
 #   * "2.5 * ref1 + 0.10 * ref2 + 0.0013 <= 2.5 * ref3"
 #   * "ref1 >= 2.9 * ref2"
-#   * "ref1 <= ref2"
+#   * "ref1 == ref2"
 #   * "ref1 >= ref1"
 #
 # Let's create a model with groups constraints on "industry sector" and

--- a/src/skfolio/exceptions.py
+++ b/src/skfolio/exceptions.py
@@ -12,6 +12,7 @@ __all__ = [
     "EquationToMatrixError",
     "GroupNotFoundError",
     "NonPositiveVarianceError",
+    "DuplicateGroupsError",
 ]
 
 
@@ -25,6 +26,10 @@ class EquationToMatrixError(Exception):
 
 class GroupNotFoundError(Exception):
     """Group name not found in the groups"""
+
+
+class DuplicateGroupsError(Exception):
+    """Group name appear in multiple group levels"""
 
 
 class NonPositiveVarianceError(Exception):

--- a/src/skfolio/optimization/convex/_distributionally_robust.py
+++ b/src/skfolio/optimization/convex/_distributionally_robust.py
@@ -125,7 +125,7 @@ class DistributionallyRobustCVaR(ConvexOptimization):
 
            * "2.5 * ref1 + 0.10 * ref2 + 0.0013 <= 2.5 * ref3"
            * "ref1 >= 2.9 * ref2"
-           * "ref1 <= ref2"
+           * "ref1 == ref2"
            * "ref1 >= ref1"
 
         With "ref1", "ref2" ... the assets names or the groups names provided
@@ -137,8 +137,8 @@ class DistributionallyRobustCVaR(ConvexOptimization):
 
             * "SPX >= 0.10" --> SPX weight must be greater than 10% (note that you can also use `min_weights`)
             * "SX5E + TLT >= 0.2" --> the sum of SX5E and TLT weights must be greater than 20%
-            * "US >= 0.7" --> the sum of all US weights must be greater than 70%
-            * "Equity <= 3 * Bond" --> the sum of all Equity weights must be less or equal to 3 times the sum of all Bond weights.
+            * "US == 0.7" --> the sum of all US weights must be equal to 70%
+            * "Equity == 3 * Bond" --> the sum of all Equity weights must be equal to 3 times the sum of all Bond weights.
             * "2*SPX + 3*Europe <= Bond + 0.05" --> mixing assets and group constraints
 
     groups : dict[str, list[str]] or array-like of shape (n_groups, n_assets), optional

--- a/src/skfolio/optimization/convex/_maximum_diversification.py
+++ b/src/skfolio/optimization/convex/_maximum_diversification.py
@@ -201,7 +201,7 @@ class MaximumDiversification(MeanRisk):
 
            * "2.5 * ref1 + 0.10 * ref2 + 0.0013 <= 2.5 * ref3"
            * "ref1 >= 2.9 * ref2"
-           * "ref1 <= ref2"
+           * "ref1 == ref2"
            * "ref1 >= ref1"
 
         With "ref1", "ref2" ... the assets names or the groups names provided
@@ -213,8 +213,8 @@ class MaximumDiversification(MeanRisk):
 
             * "SPX >= 0.10" --> SPX weight must be greater than 10% (note that you can also use `min_weights`)
             * "SX5E + TLT >= 0.2" --> the sum of SX5E and TLT weights must be greater than 20%
-            * "US >= 0.7" --> the sum of all US weights must be greater than 70%
-            * "Equity <= 3 * Bond" --> the sum of all Equity weights must be less or equal to 3 times the sum of all Bond weights.
+            * "US == 0.7" --> the sum of all US weights must be equal to 70%
+            * "Equity == 3 * Bond" --> the sum of all Equity weights must be equal to 3 times the sum of all Bond weights.
             * "2*SPX + 3*Europe <= Bond + 0.05" --> mixing assets and group constraints
 
     groups : dict[str, list[str]] or array-like of shape (n_groups, n_assets), optional

--- a/src/skfolio/optimization/convex/_mean_risk.py
+++ b/src/skfolio/optimization/convex/_mean_risk.py
@@ -334,7 +334,7 @@ class MeanRisk(ConvexOptimization):
 
            * "2.5 * ref1 + 0.10 * ref2 + 0.0013 <= 2.5 * ref3"
            * "ref1 >= 2.9 * ref2"
-           * "ref1 <= ref2"
+           * "ref1 == ref2"
            * "ref1 >= ref1"
 
         With "ref1", "ref2" ... the assets names or the groups names provided
@@ -346,8 +346,8 @@ class MeanRisk(ConvexOptimization):
 
             * "SPX >= 0.10" --> SPX weight must be greater than 10% (note that you can also use `min_weights`)
             * "SX5E + TLT >= 0.2" --> the sum of SX5E and TLT weights must be greater than 20%
-            * "US >= 0.7" --> the sum of all US weights must be greater than 70%
-            * "Equity <= 3 * Bond" --> the sum of all Equity weights must be less or equal to 3 times the sum of all Bond weights.
+            * "US == 0.7" --> the sum of all US weights must be equal to 70%
+            * "Equity == 3 * Bond" --> the sum of all Equity weights must be equal to 3 times the sum of all Bond weights.
             * "2*SPX + 3*Europe <= Bond + 0.05" --> mixing assets and group constraints
 
     groups : dict[str, list[str]] or array-like of shape (n_groups, n_assets), optional

--- a/src/skfolio/optimization/convex/_risk_budgeting.py
+++ b/src/skfolio/optimization/convex/_risk_budgeting.py
@@ -212,12 +212,12 @@ class RiskBudgeting(ConvexOptimization):
         The default (`None`) means no previous weights.
 
     linear_constraints : array-like of shape (n_constraints,), optional
-       Linear constraints.
+        Linear constraints.
         The linear constraints must match any of following patterns:
 
            * "2.5 * ref1 + 0.10 * ref2 + 0.0013 <= 2.5 * ref3"
            * "ref1 >= 2.9 * ref2"
-           * "ref1 <= ref2"
+           * "ref1 == ref2"
            * "ref1 >= ref1"
 
         With "ref1", "ref2" ... the assets names or the groups names provided
@@ -229,8 +229,8 @@ class RiskBudgeting(ConvexOptimization):
 
             * "SPX >= 0.10" --> SPX weight must be greater than 10% (note that you can also use `min_weights`)
             * "SX5E + TLT >= 0.2" --> the sum of SX5E and TLT weights must be greater than 20%
-            * "US >= 0.7" --> the sum of all US weights must be greater than 70%
-            * "Equity <= 3 * Bond" --> the sum of all Equity weights must be less or equal to 3 times the sum of all Bond weights.
+            * "US == 0.7" --> the sum of all US weights must be equal to 70%
+            * "Equity == 3 * Bond" --> the sum of all Equity weights must be equal to 3 times the sum of all Bond weights.
             * "2*SPX + 3*Europe <= Bond + 0.05" --> mixing assets and group constraints
 
     groups : dict[str, list[str]] or array-like of shape (n_groups, n_assets), optional

--- a/src/skfolio/prior/_black_litterman.py
+++ b/src/skfolio/prior/_black_litterman.py
@@ -208,13 +208,16 @@ class BlackLitterman(BasePrior):
                 ),
                 name="groups",
             )
-        self.picking_matrix_, self.views_ = equations_to_matrix(
+        self.picking_matrix_, self.views_, a_ineq, b_ineq  = equations_to_matrix(
             groups=self.groups_,
             equations=views,
             sum_to_one=True,
             raise_if_group_missing=True,
             names=("groups", "views"),
         )
+
+        if len(a_ineq) !=0:
+            raise ValueError("Inequalities (<=, >=) are not supported in views")
 
         if self.view_confidences is None:
             omega = np.diag(

--- a/src/skfolio/prior/_black_litterman.py
+++ b/src/skfolio/prior/_black_litterman.py
@@ -208,7 +208,7 @@ class BlackLitterman(BasePrior):
                 ),
                 name="groups",
             )
-        self.picking_matrix_, self.views_, a_ineq, b_ineq  = equations_to_matrix(
+        self.picking_matrix_, self.views_, a_ineq, b_ineq = equations_to_matrix(
             groups=self.groups_,
             equations=views,
             sum_to_one=True,
@@ -216,7 +216,7 @@ class BlackLitterman(BasePrior):
             names=("groups", "views"),
         )
 
-        if len(a_ineq) !=0:
+        if len(a_ineq) != 0:
             raise ValueError("Inequalities (<=, >=) are not supported in views")
 
         if self.view_confidences is None:

--- a/src/skfolio/utils/equations.py
+++ b/src/skfolio/utils/equations.py
@@ -35,7 +35,7 @@ def equations_to_matrix(
     sum_to_one: bool = False,
     raise_if_group_missing: bool = False,
     names: tuple[str, str] = ("groups", "equations"),
-) -> tuple[np.ndarray, np.ndarray,np.ndarray, np.ndarray]:
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
     """Convert a list of linear equations into the left and right matrices of the
     inequality A <= B and equality A == B.
 

--- a/src/skfolio/utils/equations.py
+++ b/src/skfolio/utils/equations.py
@@ -10,9 +10,23 @@ import warnings
 import numpy as np
 import numpy.typing as npt
 
-from skfolio.exceptions import EquationToMatrixError, GroupNotFoundError
+from skfolio.exceptions import (
+    DuplicateGroupsError,
+    EquationToMatrixError,
+    GroupNotFoundError,
+)
 
 __all__ = ["equations_to_matrix"]
+
+_EQUALITY_OPERATORS = {"==", "="}
+_INEQUALITY_OPERATORS = {">=", "<="}
+_COMPARISON_OPERATORS = _EQUALITY_OPERATORS.union(_INEQUALITY_OPERATORS)
+_SUB_ADD_OPERATORS = {"-", "+"}
+_MUL_OPERATORS = {"*"}
+_NON_MUL_OPERATORS = _COMPARISON_OPERATORS.union(_SUB_ADD_OPERATORS)
+_OPERATORS = _NON_MUL_OPERATORS.union(_MUL_OPERATORS)
+_COMPARISON_OPERATOR_SIGNS = {">=": -1, "<=": 1, "==": 1, "=": 1}
+_SUB_ADD_OPERATOR_SIGNS = {"+": 1, "-": -1}
 
 
 def equations_to_matrix(
@@ -21,9 +35,9 @@ def equations_to_matrix(
     sum_to_one: bool = False,
     raise_if_group_missing: bool = False,
     names: tuple[str, str] = ("groups", "equations"),
-) -> tuple[np.ndarray, np.ndarray]:
+) -> tuple[np.ndarray, np.ndarray,np.ndarray, np.ndarray]:
     """Convert a list of linear equations into the left and right matrices of the
-    inequality A <= B.
+    inequality A <= B and equality A == B.
 
     Parameters
     ----------
@@ -44,9 +58,9 @@ def equations_to_matrix(
 
          Example of valid equation patterns:
             * "number_1 * group_1 + number_3 <= number_4 * group_3 + number_5"
-            * "group_1 >= number * group_2"
+            * "group_1 == number * group_2"
             * "group_1 <= number"
-            * "group_1 >= number"
+            * "group_1 == number"
 
         "group_1" and "group_2" are the group names defined in `groups`.
         The second expression means that the sum of all assets in "group_1" should be
@@ -57,8 +71,8 @@ def equations_to_matrix(
                 "Equity <= 3 * Bond",
                 "US >= 1.5",
                 "Europe >= 0.5 * Japan",
-                "Japan <= 1",
-                "3*SPX + 5*SX5E <= 2*TLT + 3",
+                "Japan == 1",
+                "3*SPX + 5*SX5E == 2*TLT + 3",
             ]
 
     sum_to_one : bool
@@ -76,41 +90,104 @@ def equations_to_matrix(
 
     Returns
     -------
-    left: ndarray of shape (n_equations, n_assets)
-    right: ndarray of shape (n_equations,)
+    left_equality: ndarray of shape (n_equations_equality, n_assets)
+    right_equality: ndarray of shape (n_equations_equality,)
         The left and right matrices of the inequality A <= B.
-        If none of the group inside the equations are part of the groups, `None` is
-        returned.
-    """
-    groups = np.asarray(groups)
-    equations = np.asarray(equations)
-    if groups.ndim != 2:
-        raise ValueError(
-            f"`{names[0]}` must be a 2D array, got {groups.ndim}D array instead."
-        )
-    if equations.ndim != 1:
-        raise ValueError(
-            f"`{names[1]}` must be a 1D array, got {equations.ndim}D array instead."
-        )
 
-    n_equations = len(equations)
-    n_assets = groups.shape[1]
-    a = np.zeros((n_equations, n_assets))
-    b = np.zeros(n_equations)
-    for i, string in enumerate(equations):
+    left_inequality: ndarray of shape (n_equations_inequality, n_assets)
+    right_inequality: ndarray of shape (n_equations_inequality,)
+        The left and right matrices of the equality A == B.
+    """
+    groups = _validate_groups(groups, name=names[0])
+    equations = _validate_equations(equations, name=names[1])
+
+    a_equality = []
+    b_equality = []
+
+    a_inequality = []
+    b_inequality = []
+
+    for string in equations:
         try:
-            left, right = _string_to_equation(
+            left, right, is_inequality = _string_to_equation(
                 groups=groups,
                 string=string,
                 sum_to_one=sum_to_one,
             )
-            a[i] = left
-            b[i] = right
+            if is_inequality:
+                a_inequality.append(left)
+                b_inequality.append(right)
+            else:
+                a_equality.append(left)
+                b_equality.append(right)
         except GroupNotFoundError as e:
             if raise_if_group_missing:
                 raise
             warnings.warn(str(e), stacklevel=2)
-    return a, b
+    return (
+        np.array(a_equality),
+        np.array(b_equality),
+        np.array(a_inequality),
+        np.array(b_inequality),
+    )
+
+
+def _validate_groups(groups: npt.ArrayLike, name: str = "groups") -> np.ndarray:
+    """Validate groups by checking its dim and if group names don't appear in multiple
+    levels and convert to numpy array.
+
+    Parameters
+    ----------
+    groups : array-like of shape (n_groups, n_assets)
+        2D-array of strings.
+
+    Returns
+    -------
+    groups : ndarray of shape (n_groups, n_assets)
+        2D-array of strings.
+    """
+    groups = np.asarray(groups)
+    if groups.ndim != 2:
+        raise ValueError(
+            f"`{name} must be a 2D array, got {groups.ndim}D array instead."
+        )
+    n = len(groups)
+    group_sets = [set(groups[i]) for i in range(n)]
+    for i in range(n - 1):
+        for e in group_sets[i]:
+            for j in range(i + 1, n):
+                if e in group_sets[j]:
+                    raise DuplicateGroupsError(
+                        f"'{e}' appear in two levels: {list(groups[i])} "
+                        f"and {list(groups[i])}. "
+                        f"{name} must be in only one level."
+                    )
+
+    return groups
+
+
+def _validate_equations(
+    equations: npt.ArrayLike, name: str = "equations"
+) -> np.ndarray:
+    """Validate equations by checking its dim and convert to numpy array.
+
+    Parameters
+    ----------
+    equations : array-like of shape (n_equations,)
+        1D array of equations.
+
+    Returns
+    -------
+    equations : ndarray of shape (n_equations,)
+        1D array of equations.
+    """
+    equations = np.asarray(equations)
+
+    if equations.ndim != 1:
+        raise ValueError(
+            f"`{name}` must be a 1D array, got {equations.ndim}D array instead."
+        )
+    return equations
 
 
 def _matching_array(values: np.ndarray, key: str, sum_to_one: bool) -> np.ndarray:
@@ -145,11 +222,7 @@ def _matching_array(values: np.ndarray, key: str, sum_to_one: bool) -> np.ndarra
     return arr / s
 
 
-_operator_mapping = {">=": -1, "<=": 1, "==": 1, "=": 1}
-_operator_signs = {"+": 1, "-": -1}
-
-
-def _inequality_operator_sign(operator: str) -> int:
+def _comparison_operator_sign(operator: str) -> int:
     """Convert the operators '>=', "==" and '<=' into the corresponding integer
     values -1, 1 and 1, respectively.
 
@@ -164,14 +237,14 @@ def _inequality_operator_sign(operator: str) -> int:
         Operator sign: 1 or -1.
     """
     try:
-        return _operator_mapping[operator]
+        return _COMPARISON_OPERATOR_SIGNS[operator]
     except KeyError:
         raise EquationToMatrixError(
             f"operator '{operator}' is not valid. It should be '<=' or '>='"
         ) from None
 
 
-def _operator_sign(operator: str) -> int:
+def _sub_add_operator_sign(operator: str) -> int:
     """Convert the operators '+' and '-' into 1 or -1
 
     Parameters
@@ -185,7 +258,7 @@ def _operator_sign(operator: str) -> int:
        Operator sign: 1 or -1.
     """
     try:
-        return _operator_signs[operator]
+        return _SUB_ADD_OPERATOR_SIGNS[operator]
     except KeyError:
         raise EquationToMatrixError(
             f"operator '{operator}' is not valid. It should be be '+' or '-'"
@@ -211,13 +284,41 @@ def _string_to_float(string: str) -> float:
         raise EquationToMatrixError(f"Unable to convert {string} into float") from None
 
 
+def _split_equation_string(string: str) -> list[str]:
+    """Split an equation strings by operators"""
+    comp_pattern = "(?=" + "|".join([".+\\" + e for e in _COMPARISON_OPERATORS]) + ")"
+    if not bool(re.match(comp_pattern, string)):
+        raise EquationToMatrixError(
+            f"The string must contains a comparison operator: "
+            f"{list(_COMPARISON_OPERATORS)}"
+        )
+
+    # Regex to match only '>' and '<' but not '<=' or '>='
+    invalid_pattern = r"(?<!<)(?<!<=)>(?!=)|(?<!>)<(?!=)"
+    invalid_matches = re.findall(invalid_pattern, string)
+
+    if len(invalid_matches) > 0:
+        raise EquationToMatrixError(
+            f"{invalid_matches[0]} is an invalid comparison operator. "
+            f"Valid comparison operators are: {list(_COMPARISON_OPERATORS)}"
+        )
+
+    # '==' needs to be before '='
+    operators = sorted(_OPERATORS, reverse=True)
+    pattern = "((?:" + "|".join(["\\" + e for e in operators]) + "))"
+    res = [x.strip() for x in re.split(pattern, string)]
+    res = [x for x in res if x != ""]
+    return res
+
+
 def _string_to_equation(
     groups: np.ndarray,
     string: str,
     sum_to_one: bool,
-) -> tuple[np.ndarray, float]:
+) -> tuple[np.ndarray, float, bool]:
     """Convert a string to a left 1D-array and right float of the form:
-    `groups @ left <= right`.
+    `groups @ left <= right` or `groups @ left == right` and return whether it's an
+    equality or inequality.
 
     Parameters
     ----------
@@ -232,20 +333,14 @@ def _string_to_equation(
 
     Returns
     -------
-    left: 1D-array of shape (n_assets,)
-    right: float
+    left : 1D-array of shape (n_assets,)
+    right : float
+    is_inequality : bool
     """
     n = groups.shape[1]
-    operators = ["-", "+", "*", ">=", "<=", "==", "="]
-    invalid_operators = [">", "<"]
-    pattern = re.compile(r"((?:" + "|\\".join(operators) + r"))")
-    invalid_pattern = re.compile(r"((?:" + "|\\".join(invalid_operators) + r"))")
     err_msg = f"Wrong pattern encountered while converting the string '{string}'"
 
-    res = re.split(pattern, string)
-    res = [x.strip() for x in res]
-    res = [x for x in res if x != ""]
-    iterator = iter(res)
+    iterator = iter(_split_equation_string(string))
     group_names = set(groups.flatten())
 
     def is_group(name: str) -> bool:
@@ -254,7 +349,8 @@ def _string_to_equation(
     left = np.zeros(n)
     right = 0
     main_sign = 1
-    inequality_sign = None
+    comparison_sign = None
+    is_inequality = None
     e = next(iterator, None)
     i = 0
     while True:
@@ -264,23 +360,27 @@ def _string_to_equation(
         if e is None:
             break
         sign = 1
-        if e in [">=", "<=", "==", "="]:
+        if e in _COMPARISON_OPERATORS:
+            if e in _INEQUALITY_OPERATORS:
+                is_inequality = True
+            else:
+                is_inequality = False
             main_sign = -1
-            inequality_sign = _inequality_operator_sign(e)
+            comparison_sign = _comparison_operator_sign(e)
             e = next(iterator, None)
-            if e in ["-", "+"]:
-                sign *= _operator_sign(e)
+            if e in _SUB_ADD_OPERATORS:
+                sign *= _sub_add_operator_sign(e)
                 e = next(iterator, None)
-        elif e in ["-", "+"]:
-            sign *= _operator_sign(e)
+        elif e in _SUB_ADD_OPERATORS:
+            sign *= _sub_add_operator_sign(e)
             e = next(iterator, None)
-        elif e == "*":
+        elif e in _MUL_OPERATORS:
             raise EquationToMatrixError(
                 f"{err_msg}: the character '{e}' is wrongly positioned"
             )
         sign *= main_sign
         # next can only be a number or a group
-        if e is None or e in operators:
+        if e is None or e in _OPERATORS:
             raise EquationToMatrixError(
                 f"{err_msg}: the character '{e}' is wrongly positioned"
             )
@@ -288,20 +388,14 @@ def _string_to_equation(
             arr = _matching_array(values=groups, key=e, sum_to_one=sum_to_one)
             # next can only be a '*' or an ['-', '+', '>=', '<=', '==', '='] or None
             e = next(iterator, None)
-            if e is None or e in ["-", "+", ">=", "<=", "==", "="]:
+            if e is None or e in _NON_MUL_OPERATORS:
                 left += sign * arr
-            elif e == "*":
+            elif e in _MUL_OPERATORS:
                 # next can only a number
                 e = next(iterator, None)
                 try:
                     number = float(e)
                 except ValueError:
-                    invalid_ops = invalid_pattern.findall(e)
-                    if len(invalid_ops) > 0:
-                        raise EquationToMatrixError(
-                            f"{invalid_ops[0]} is an invalid operator. Valid operators"
-                            f" are: {operators}"
-                        ) from None
                     raise GroupNotFoundError(
                         f"{err_msg}: the group '{e}' is missing from the groups"
                         f" {groups}"
@@ -317,18 +411,12 @@ def _string_to_equation(
             try:
                 number = float(e)
             except ValueError:
-                invalid_ops = invalid_pattern.findall(e)
-                if len(invalid_ops) > 0:
-                    raise EquationToMatrixError(
-                        f"{invalid_ops[0]} is an invalid operator. Valid operators are:"
-                        f" {operators}"
-                    ) from None
                 raise GroupNotFoundError(
                     f"{err_msg}: the group '{e}' is missing from the groups {groups}"
                 ) from None
             # next can only be a '*' or an operator or None
             e = next(iterator, None)
-            if e == "*":
+            if e in _MUL_OPERATORS:
                 # next can only a group
                 e = next(iterator, None)
                 if not is_group(e):
@@ -338,14 +426,14 @@ def _string_to_equation(
                 arr = _matching_array(values=groups, key=e, sum_to_one=sum_to_one)
                 left += number * sign * arr
                 e = next(iterator, None)
-            elif e is None or e in ["-", "+", ">=", "<=", "==", "="]:
+            elif e is None or e in _NON_MUL_OPERATORS:
                 right += number * sign
             else:
                 raise EquationToMatrixError(
                     f"{err_msg}: the character '{e}' is wrongly positioned"
                 )
 
-    left *= inequality_sign
-    right *= -inequality_sign
+    left *= comparison_sign
+    right *= -comparison_sign
 
-    return left, right
+    return left, right, is_inequality

--- a/tests/test_portfolio/test_portfolio.py
+++ b/tests/test_portfolio/test_portfolio.py
@@ -335,11 +335,8 @@ def test_portfolio_slots(X, weights):
 
 def test_copy(X, weights):
     portfolio = Portfolio(X=X, weights=weights, annualized_factor=252)
-    try:
+    with pytest.raises(AttributeError):
         _ = portfolio._assets_names
-        raise
-    except AttributeError:
-        pass
     _ = portfolio.nonzero_assets
     _ = copy(portfolio)
 

--- a/tests/test_prior/test_black_litterman.py
+++ b/tests/test_prior/test_black_litterman.py
@@ -11,7 +11,7 @@ def test_views_to_matrix(X):
     views = ["AAPL - BBY == 0.03 ", "CVX - KO== 0.04", "MSFT == 0.06 "]
     groups = np.array([X.columns])
 
-    picking_matrix, views = equations_to_matrix(
+    picking_matrix, views, _, _ = equations_to_matrix(
         groups=groups, equations=views, sum_to_one=True
     )
     np.testing.assert_almost_equal(

--- a/tests/test_utils/test_equations.py
+++ b/tests/test_utils/test_equations.py
@@ -1,52 +1,161 @@
 import numpy as np
+import pytest
 
-from skfolio.exceptions import EquationToMatrixError
-from skfolio.utils.equations import _string_to_equation, equations_to_matrix
+from skfolio.exceptions import DuplicateGroupsError, EquationToMatrixError
+from skfolio.utils.equations import (
+    _COMPARISON_OPERATORS,
+    _split_equation_string,
+    _string_to_equation,
+    equations_to_matrix,
+)
+
+
+@pytest.fixture
+def groups():
+    groups = np.array(
+        [["a", "a", "b", "b"], ["c", "c", "j", "c"], ["d", "e", "d", "e"]]
+    )
+    return groups
+
+
+def test_split_equation_string():
+    for op in _COMPARISON_OPERATORS:
+        for c in ["", " ", "   "]:
+            string = "left" + c + op + c + "right"
+            res = _split_equation_string(string)
+            assert len(res) == 3
+
+
+def test_split_equation_string_error():
+    with pytest.raises(EquationToMatrixError):
+        _split_equation_string("a*b")
+
+    with pytest.raises(EquationToMatrixError):
+        _split_equation_string("a>3")
+
+    with pytest.raises(EquationToMatrixError):
+        _split_equation_string("a<3")
 
 
 def test_string_to_equation():
     string = "-5 - 3.5 * a + b - 2*c + 2 <= -1 + e*2.1 + f +6.5"
     groups = np.array([["a", "b", "c", "e", "f"]])
-    left, right = _string_to_equation(groups=groups, string=string, sum_to_one=False)
+    left, right, is_inequality = _string_to_equation(
+        groups=groups, string=string, sum_to_one=False
+    )
     np.testing.assert_array_almost_equal(left, np.array([-3.5, 1.0, -2.0, -2.1, -1.0]))
+    assert is_inequality is True
     assert right == 8.5
+
     string = "5 - 3.5 * a + a - c*2 + 2 +f >= -1 + e*2.1 + f +6.5"
     groups = np.array([["a", "a", "c", "e", "f"]])
-    left, right = _string_to_equation(groups=groups, string=string, sum_to_one=False)
+    left, right, is_inequality = _string_to_equation(
+        groups=groups, string=string, sum_to_one=False
+    )
+    assert is_inequality is True
     np.testing.assert_array_almost_equal(left, np.array([2.5, 2.5, 2, 2.1, 0]))
     assert right == 1.5
 
-
-def test_equations_to_matrix():
-    groups = np.array(
-        [["a", "a", "b", "b"], ["c", "a", "c", "a"], ["d", "e", "d", "e"]]
+    string = "5 - 3.5 * a + a - c*2 + 2 +f == -1 + e*2.1 + f +6.5"
+    groups = np.array([["a", "a", "c", "e", "f"]])
+    left, right, is_inequality = _string_to_equation(
+        groups=groups, string=string, sum_to_one=False
     )
+    assert is_inequality is False
+    np.testing.assert_array_almost_equal(left, np.array([-2.5, -2.5, -2, -2.1, 0]))
+    assert right == -1.5
 
-    equations = ["a <= 2 * b ", "a <= 1.2", "d >= 3 ", " e >=  .5*d"]
-    a, b = equations_to_matrix(groups=groups, equations=equations)
+
+def test_equations_to_matrix_inequality(groups):
+    equations = ["a <= 2 * b ", "a <= 1.2", "3*c >= 0", "d >= 3 ", " e >=  .5*d"]
+    a_eq, b_eq, a_ineq, b_ineq = equations_to_matrix(groups=groups, equations=equations)
+    assert len(a_eq) == 0
+    assert len(b_eq) == 0
     np.testing.assert_array_almost_equal(
-        a,
+        a_ineq,
         np.array(
             [
-                [1.0, 1.0, -2.0, -1.0],
-                [1.0, 1.0, 0.0, 1.0],
+                [1.0, 1.0, -2.0, -2.0],
+                [1.0, 1.0, 0.0, 0.0],
+                [-3.0, -3.0, 0.0, -3.0],
                 [-1.0, 0.0, -1.0, 0.0],
                 [0.5, -1.0, 0.5, -1.0],
             ]
         ),
     )
 
-    np.testing.assert_array_almost_equal(b, np.array([0.0, 1.2, -3.0, 0.0]))
+    np.testing.assert_array_almost_equal(b_ineq, np.array([0.0, 1.2, 0, -3.0, 0.0]))
 
+
+def test_equations_to_matrix_equality(groups):
+    equations = ["a == 2 * b ", "a = 1.2", "3*c = 0", "d == 3 ", " e ==  .5*d"]
+    a_eq, b_eq, a_ineq, b_ineq = equations_to_matrix(groups=groups, equations=equations)
+    assert len(a_ineq) == 0
+    assert len(b_ineq) == 0
+    np.testing.assert_array_almost_equal(
+        a_eq,
+        np.array(
+            [
+                [1.0, 1.0, -2.0, -2.0],
+                [1.0, 1.0, 0.0, 0.0],
+                [3.0, 3.0, 0.0, 3.0],
+                [1.0, 0.0, 1.0, 0.0],
+                [-0.5, 1.0, -0.5, 1.0],
+            ]
+        ),
+    )
+
+    np.testing.assert_array_almost_equal(b_eq, np.array([0.0, 1.2, 0, 3.0, 0.0]))
+
+
+def test_equations_to_matrix_mix(groups):
+    equations = ["a <= 2 * b ", "a = 1.2", "3*c = 0", "d == 3 ", " e >=  .5*d"]
+    a_eq, b_eq, a_ineq, b_ineq = equations_to_matrix(groups=groups, equations=equations)
+
+    np.testing.assert_array_almost_equal(
+        a_eq,
+        np.array(
+            [
+                [1.0, 1.0, 0.0, 0.0],
+                [3.0, 3.0, 0.0, 3.0],
+                [1.0, 0.0, 1.0, 0.0],
+            ]
+        ),
+    )
+
+    np.testing.assert_array_almost_equal(b_eq, np.array([1.2, 0, 3.0]))
+
+    np.testing.assert_array_almost_equal(
+        a_ineq,
+        np.array(
+            [
+                [1.0, 1.0, -2.0, -2.0],
+                [0.5, -1.0, 0.5, -1.0],
+            ]
+        ),
+    )
+
+    np.testing.assert_array_almost_equal(b_ineq, np.array([0.0, 0.0]))
+
+
+def test_equations_to_matrix_error(groups):
     for c in [["a == "], ["a <= 2*bb"], ["a <= 2*b*c"]]:
-        try:
+        with pytest.raises(EquationToMatrixError):
             equations_to_matrix(groups=groups, equations=c)
-            raise
-        except EquationToMatrixError:
-            pass
 
 
-def views():
+def test_equations_to_matrix_duplicate_groups_error():
+    groups = np.array(
+        [["a", "a", "b", "b"], ["c", "a", "c", "a"], ["d", "e", "d", "e"]]
+    )
+
+    equations = ["a <= 2 * b ", "a <= 1.2", "d >= 3 ", " e >=  .5*d"]
+
+    with pytest.raises(DuplicateGroupsError):
+        _ = equations_to_matrix(groups=groups, equations=equations)
+
+
+def test_views():
     groups = np.array(
         [
             [
@@ -64,11 +173,15 @@ def views():
     equations = [
         "Health Care - Financials == 0.03 ",
         "Industrials - Utilities== 0.04",
-        "Energy == 0.06 ",
+        "Energy = 0.06 ",
     ]
-    a, b = equations_to_matrix(groups=groups, equations=equations, sum_to_one=True)
+    a_eq, b_eq, a_ineq, b_ineq = equations_to_matrix(
+        groups=groups, equations=equations, sum_to_one=True
+    )
+    assert len(a_ineq) == 0
+    assert len(b_ineq) == 0
     assert np.array_equal(
-        a,
+        a_eq,
         np.array(
             [
                 [0.5, 0.5, 0.0, 0.0, -1.0, 0.0, 0.0],
@@ -77,4 +190,4 @@ def views():
             ]
         ),
     )
-    assert np.array_equal(b, np.array([0.03, 0.04, 0.06]))
+    assert np.array_equal(b_eq, np.array([0.03, 0.04, 0.06]))


### PR DESCRIPTION
<!--
Welcome to skfolio, and thanks for contributing!
-->

#### Reference Issues/PRs
Fixes #82


#### What does this implement/fix? Explain your changes.
`linear_constraints` only supported inequalities ">=" and "<=". It now support equalities "=" and "==".
Also implemented better error handling. 

#### Does your contribution introduce a new dependency? If yes, which one?
No

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

#### Did you add any tests for the change?
Yes

#### Any other comments?
<!--
We value all user contributions, no matter how small or complex they are. Please feel free to any additional comments.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.
- [ ] Optionally, I've added myself and possibly others to the [CODEOWNERS](https://github.com/skfolio/skfolio/blob/main/CODEOWNERS) file - do this if you want to become the owner or maintainer of an estimator you added.

##### For new estimators
- [ ] I've added the estimator to the API reference in `docs/api.rst`.
- [ ] I've added one or more illustrative usage examples to the docstring and the `examples` section.

<!--
Thanks for contributing!
-->