### PR TITLE
[BUG] HERC weight constraints

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -617,4 +617,5 @@ Functions
     stats.compute_optimal_n_clusters
     stats.rand_weights
     stats.rand_weights_dirichlet
+    stats.minimize_relative_weight_deviation
 

--- a/src/skfolio/optimization/cluster/hierarchical/_base.py
+++ b/src/skfolio/optimization/cluster/hierarchical/_base.py
@@ -52,8 +52,6 @@ class BaseHierarchicalOptimization(BaseOptimization, ABC):
             * ENTROPIC_RISK_MEASURE
             * FOURTH_CENTRAL_MOMENT
             * FOURTH_LOWER_PARTIAL_MOMENT
-            * SKEW
-            * KURTOSIS
 
         The default is `RiskMeasure.VARIANCE`.
 
@@ -80,12 +78,12 @@ class BaseHierarchicalOptimization(BaseOptimization, ABC):
 
     min_weights : float | dict[str, float] | array-like of shape (n_assets, ), default=0.0
         Minimum assets weights (weights lower bounds). Negative weights are not allowed.
-        If a float is provided, it is applied to each asset. `None` is equivalent to
-        `-np.Inf` (no lower bound). If a dictionary is provided, its (key/value) pair
-        must be the (asset name/asset minium weight) and the input `X` of the `fit`
-        methods must be a DataFrame with the assets names in columns. When using a
-        dictionary, assets values that are not provided are assigned a minimum weight
-        of `0.0`. The default is 0.0 (no short selling).
+        If a float is provided, it is applied to each asset.
+        If a dictionary is provided, its (key/value) pair must be the
+        (asset name/asset minium weight) and the input `X` of the `fit` methods must be
+        a DataFrame with the assets names in columns.
+        When using a dictionary, assets values that are not provided are assigned a
+        minimum weight of `0.0`. The default is 0.0 (no short selling).
 
         Example:
 
@@ -96,12 +94,12 @@ class BaseHierarchicalOptimization(BaseOptimization, ABC):
 
     max_weights : float | dict[str, float] | array-like of shape (n_assets, ), default=1.0
         Maximum assets weights (weights upper bounds). Weights above 1.0 are not
-        allowed. If a float is provided, it is applied to each asset. `None` is
-        equivalent to `+np.Inf` (no upper bound). If a dictionary is provided, its
-        (key/value) pair must be the (asset name/asset maximum weight) and the input `X`
-        of the `fit` method must be a DataFrame with the assets names in columns. When
-        using a dictionary, assets values that are not provided are assigned a minimum
-        weight of `1.0`. The default is 1.0 (each asset is below 100%).
+        allowed. If a float is provided, it is applied to each asset.
+        If a dictionary is provided, its (key/value) pair must be the
+        (asset name/asset maximum weight) and the input `X` of the `fit` method must be
+        a DataFrame with the assets names in columns.
+        When using a dictionary, assets values that are not provided are assigned a
+        minimum weight of `1.0`. The default is 1.0 (each asset is below 100%).
 
         Example:
 
@@ -387,57 +385,6 @@ class BaseHierarchicalOptimization(BaseOptimization, ABC):
             )
 
         return min_weights, max_weights
-
-    @staticmethod
-    def _apply_weight_constraints_to_alpha(
-        alpha: float,
-        max_weights: np.ndarray,
-        min_weights: np.ndarray,
-        weights: np.ndarray,
-        left_cluster: np.ndarray,
-        right_cluster: np.ndarray,
-    ) -> float:
-        """Apply weight constraints to the alpha multiplication factor of the
-        Hierarchical Tree Clustering algorithm.
-
-        Parameters
-        ----------
-        alpha : float
-            The alpha multiplication factor of the Hierarchical Tree Clustering
-            algorithm.
-
-         min_weights : ndarray of shape (n_assets,)
-            The weight lower bound 1D array.
-
-        max_weights : ndarray of shape (n_assets,)
-            The weight upper bound 1D array.
-
-        weights : np.ndarray of shape (n_assets,)
-            The assets weights.
-
-        left_cluster : ndarray of shape (n_left_cluster,)
-            Indices of the left cluster weights.
-
-        right_cluster : ndarray of shape (n_right_cluster,)
-            Indices of the right cluster weights.
-
-        Returns
-        -------
-        value : float
-            The transformed alpha incorporating the weight constraints.
-        """
-        alpha = min(
-            np.sum(max_weights[left_cluster]) / weights[left_cluster[0]],
-            max(np.sum(min_weights[left_cluster]) / weights[left_cluster[0]], alpha),
-        )
-        alpha = 1 - min(
-            np.sum(max_weights[right_cluster]) / weights[right_cluster[0]],
-            max(
-                np.sum(min_weights[right_cluster]) / weights[right_cluster[0]],
-                1 - alpha,
-            ),
-        )
-        return alpha
 
     def get_metadata_routing(self):
         # noinspection PyTypeChecker

--- a/src/skfolio/optimization/cluster/hierarchical/_herc.py
+++ b/src/skfolio/optimization/cluster/hierarchical/_herc.py
@@ -3,8 +3,7 @@
 # Copyright (c) 2023
 # Author: Hugo Delatte <delatte.hugo@gmail.com>
 # License: BSD 3 clause
-# The risk measure generalization and constraint features are derived
-# from Riskfolio-Lib, Copyright (c) 2020-2023, Dany Cajas, Licensed under BSD 3 clause.
+# Weight constraints is a novel implementation, see docstring for more details.
 
 import numpy as np
 import numpy.typing as npt
@@ -20,6 +19,7 @@ from skfolio.optimization.cluster.hierarchical._base import (
     BaseHierarchicalOptimization,
 )
 from skfolio.prior import BasePrior, EmpiricalPrior
+from skfolio.utils.stats import minimize_relative_weight_deviation
 from skfolio.utils.tools import check_estimator
 
 
@@ -44,6 +44,32 @@ class HierarchicalEqualRiskContribution(BaseHierarchicalOptimization):
         The default linkage method is set to the Ward variance minimization algorithm,
         which is more stable and has better properties than the single-linkage
         method [4]_.
+
+        Also, the initial paper does not provide an algorithm for handling weight
+        constraints, and no standard solution currently exists.
+        In contrast to HRP (Hierarchical Risk Parity), where weight constraints
+        can be applied to the split factor at each bisection step, HERC
+        (Hierarchical Equal Risk Contribution) cannot incorporate weight constraints
+        during the intermediate steps of the allocation. Therefore, in HERC, the
+        weight constraints must be enforced after the top-down allocation has been
+        completed.
+        In skfolio, we minimize the relative deviation of the final weights from
+        the initial weights. This is formulated as a convex optimization problem:
+
+        .. math::
+            \begin{cases}
+            \begin{aligned}
+            &\min_{w} & & \Vert \frac{w - w_{init}}{w_{init}} \Vert_{2}^{2} \\
+            &\text{s.t.} & & \sum_{i=1}^{N} w_{i} = 1 \\
+            & & & w_{min} \leq w_i \leq w_{max}, \quad \forall i
+            \end{aligned}
+            \end{cases}
+
+        The reason for minimizing the relative deviation (as opposed to the absolute
+        deviation) is that we want to limit the impact on the risk contribution of
+        each asset. Since HERC allocates inversely to risk, adjusting the weights
+        based on relative deviation ensures that the assets' risk contributions
+        remain proportionally consistent with the initial allocation.
 
     Parameters
     ----------
@@ -70,8 +96,6 @@ class HierarchicalEqualRiskContribution(BaseHierarchicalOptimization):
             * ENTROPIC_RISK_MEASURE
             * FOURTH_CENTRAL_MOMENT
             * FOURTH_LOWER_PARTIAL_MOMENT
-            * SKEW
-            * KURTOSIS
 
         The default is `RiskMeasure.VARIANCE`.
 
@@ -98,12 +122,12 @@ class HierarchicalEqualRiskContribution(BaseHierarchicalOptimization):
 
     min_weights : float | dict[str, float] | array-like of shape (n_assets, ), default=0.0
         Minimum assets weights (weights lower bounds). Negative weights are not allowed.
-        If a float is provided, it is applied to each asset. `None` is equivalent to
-        `-np.Inf` (no lower bound). If a dictionary is provided, its (key/value) pair
-        must be the (asset name/asset minium weight) and the input `X` of the `fit`
-        methods must be a DataFrame with the assets names in columns. When using a
-        dictionary, assets values that are not provided are assigned a minimum weight
-        of `0.0`. The default is 0.0 (no short selling).
+        If a float is provided, it is applied to each asset.
+        If a dictionary is provided, its (key/value) pair must be the
+        (asset name/asset minium weight) and the input `X` of the `fit` methods must be
+        a DataFrame with the assets names in columns.
+        When using a dictionary, assets values that are not provided are assigned a
+        minimum weight of `0.0`. The default is 0.0 (no short selling).
 
         Example:
 
@@ -114,12 +138,12 @@ class HierarchicalEqualRiskContribution(BaseHierarchicalOptimization):
 
     max_weights : float | dict[str, float] | array-like of shape (n_assets, ), default=1.0
         Maximum assets weights (weights upper bounds). Weights above 1.0 are not
-        allowed. If a float is provided, it is applied to each asset. `None` is
-        equivalent to `+np.Inf` (no upper bound). If a dictionary is provided, its
-        (key/value) pair must be the (asset name/asset maximum weight) and the input `X`
-        of the `fit` method must be a DataFrame with the assets names in columns. When
-        using a dictionary, assets values that are not provided are assigned a minimum
-        weight of `1.0`. The default is 1.0 (each asset is below 100%).
+        allowed. If a float is provided, it is applied to each asset.
+        If a dictionary is provided, its (key/value) pair must be the
+        (asset name/asset maximum weight) and the input `X` of the `fit` method must be
+        a DataFrame with the assets names in columns.
+        When using a dictionary, assets values that are not provided are assigned a
+        minimum weight of `1.0`. The default is 1.0 (each asset is below 100%).
 
         Example:
 
@@ -208,6 +232,19 @@ class HierarchicalEqualRiskContribution(BaseHierarchicalOptimization):
         `management_fees`, `previous_weights` and `risk_free_rate` are copied from the
         optimization model and passed to the portfolio.
 
+    solver : str, default="CLARABEL"
+        The solver used for the weights constraints optimization. The default is
+        "CLARABEL" which is written in Rust and has better numerical stability and
+        performance than ECOS and SCS.
+        For more details about available solvers, check the CVXPY documentation:
+        https://www.cvxpy.org/tutorial/advanced/index.html#choosing-a-solver
+
+    solver_params : dict, optional
+        Solver parameters. For example, `solver_params=dict(verbose=True)`.
+        The default (`None`) is to use the CVXPY default.
+        For more details about solver arguments, check the CVXPY documentation:
+        https://www.cvxpy.org/tutorial/advanced/index.html#setting-solver-options
+
     Attributes
     ----------
     weights_ : ndarray of shape (n_assets,)
@@ -251,6 +288,8 @@ class HierarchicalEqualRiskContribution(BaseHierarchicalOptimization):
         hierarchical_clustering_estimator: HierarchicalClustering | None = None,
         min_weights: skt.MultiInput | None = 0.0,
         max_weights: skt.MultiInput | None = 1.0,
+        solver: str = "CLARABEL",
+        solver_params: dict | None = None,
         transaction_costs: skt.MultiInput = 0.0,
         management_fees: skt.MultiInput = 0.0,
         previous_weights: skt.MultiInput | None = None,
@@ -268,6 +307,8 @@ class HierarchicalEqualRiskContribution(BaseHierarchicalOptimization):
             previous_weights=previous_weights,
             portfolio_params=portfolio_params,
         )
+        self.solver = solver
+        self.solver_params = solver_params
 
     def fit(
         self, X: npt.ArrayLike, y: None = None, **fit_params
@@ -301,6 +342,13 @@ class HierarchicalEqualRiskContribution(BaseHierarchicalOptimization):
             raise TypeError(
                 "`risk_measure` must be of type `RiskMeasure` or `ExtraRiskMeasure`"
             )
+
+        if self.risk_measure in [ExtraRiskMeasure.SKEW, ExtraRiskMeasure.KURTOSIS]:
+            # Because Skew and Kurtosis can take negative values
+            raise ValueError(
+                f"risk_measure {self.risk_measure} currently not supported" f"in HERC"
+            )
+
         self.prior_estimator_ = check_estimator(
             self.prior_estimator,
             default=EmpiricalPrior(),
@@ -393,20 +441,11 @@ class HierarchicalEqualRiskContribution(BaseHierarchicalOptimization):
 
             left_cluster = np.array(left_cluster)
             right_cluster = np.array(right_cluster)
+
             left_risk = np.sum(cluster_risks[left_cluster])
             right_risk = np.sum(cluster_risks[right_cluster])
 
             alpha = 1 - left_risk / (left_risk + right_risk)
-
-            # Weights constraints
-            alpha = self._apply_weight_constraints_to_alpha(
-                alpha=alpha,
-                weights=weights,
-                max_weights=max_weights,
-                min_weights=min_weights,
-                left_cluster=left_cluster,
-                right_cluster=right_cluster,
-            )
 
             clusters_weights[left_cluster] *= alpha
             clusters_weights[right_cluster] *= 1 - alpha
@@ -421,5 +460,15 @@ class HierarchicalEqualRiskContribution(BaseHierarchicalOptimization):
         for i, cluster_ids in enumerate(clusters):
             weights[cluster_ids] *= clusters_weights[i]
 
+        # Apply weights constraints
+        weights = minimize_relative_weight_deviation(
+            weights=weights,
+            min_weights=min_weights,
+            max_weights=max_weights,
+            solver=self.solver,
+            solver_params=self.solver_params,
+        )
+
         self.weights_ = weights
+
         return self

--- a/src/skfolio/utils/stats.py
+++ b/src/skfolio/utils/stats.py
@@ -504,14 +504,14 @@ def minimize_relative_weight_deviation(
     Apply weight constraints to an initial array of weights by minimizing the relative
     weight deviation of the final weights from the initial weights.
 
-    .. math::   \begin{cases}
-                \begin{aligned}
-                &\min_{w} & & \Vert \frac{w - w_{init}}{w_{init}} \Vert_{2}^{2} \\
-                &\text{s.t.} & & \sum_{i=1}^{N} w_{i} = 1 \\
-                & & & w \ge w_{min} \\
-                & & & w \le w_{max}
-                \end{aligned}
-                \end{cases}
+    .. math::
+            \begin{cases}
+            \begin{aligned}
+            &\min_{w} & & \Vert \frac{w - w_{init}}{w_{init}} \Vert_{2}^{2} \\
+            &\text{s.t.} & & \sum_{i=1}^{N} w_{i} = 1 \\
+            & & & w_{min} \leq w_i \leq w_{max}, \quad \forall i
+            \end{aligned}
+            \end{cases}
 
     Parameters
     ----------

--- a/src/skfolio/utils/stats.py
+++ b/src/skfolio/utils/stats.py
@@ -10,9 +10,11 @@ import warnings
 # Statsmodels, Copyright (C) 2006, Jonathan E. Taylor, Licensed under BSD 3 clause.
 from enum import auto
 
+import cvxpy as cp
 import numpy as np
 import scipy.cluster.hierarchy as sch
 import scipy.optimize as sco
+import scipy.sparse.linalg as scl
 import scipy.spatial.distance as scd
 import scipy.special as scs
 from scipy.sparse import csr_matrix
@@ -34,6 +36,7 @@ __all__ = [
     "compute_optimal_n_clusters",
     "rand_weights",
     "rand_weights_dirichlet",
+    "minimize_relative_weight_deviation",
 ]
 
 
@@ -488,3 +491,87 @@ def compute_optimal_n_clusters(distance: np.ndarray, linkage_matrix: np.ndarray)
     # k=0 represents one cluster
     k = np.argmax(gaps) + 2
     return k
+
+
+def minimize_relative_weight_deviation(
+    weights: np.ndarray,
+    min_weights: np.ndarray,
+    max_weights: np.ndarray,
+    solver: str = "CLARABEL",
+    solver_params: dict | None = None,
+) -> np.ndarray:
+    r"""
+    Apply weight constraints to an initial array of weights by minimizing the relative
+    weight deviation of the final weights from the initial weights.
+
+    .. math::   \begin{cases}
+                \begin{aligned}
+                &\min_{w} & & \Vert \frac{w - w_{init}}{w_{init}} \Vert_{2}^{2} \\
+                &\text{s.t.} & & \sum_{i=1}^{N} w_{i} = 1 \\
+                & & & w \ge w_{min} \\
+                & & & w \le w_{max}
+                \end{aligned}
+                \end{cases}
+
+    Parameters
+    ----------
+    weights : ndarray of shape (n_assets,)
+        Initial weights.
+
+    min_weights : ndarray of shape (n_assets,)
+        Minimum assets weights (weights lower bounds).
+
+    max_weights : ndarray of shape (n_assets,)
+        Maximum assets weights (weights upper bounds).
+
+    solver : str, default="CLARABEL"
+        The solver to use. The default is "CLARABEL" which is written in Rust and has
+        better numerical stability and performance than ECOS and SCS.
+        For more details about available solvers, check the CVXPY documentation:
+        https://www.cvxpy.org/tutorial/advanced/index.html#choosing-a-solver
+
+    solver_params : dict, optional
+        Solver parameters. For example, `solver_params=dict(verbose=True)`.
+        The default (`None`) is to use the CVXPY default.
+        For more details about solver arguments, check the CVXPY documentation:
+        https://www.cvxpy.org/tutorial/advanced/index.html#setting-solver-options
+    """
+    if not (weights.shape == min_weights.shape == max_weights.shape):
+        raise ValueError("`min_weights` and `max_weights` must have same size")
+
+    if np.any(weights < 0):
+        raise ValueError("Initial weights must be strictly positive")
+
+    if not np.isclose(np.sum(weights), 1.0):
+        raise ValueError("Initial weights must sum to one")
+
+    if np.any(max_weights < min_weights):
+        raise ValueError("`min_weights` must be lower or equal to `max_weights`")
+
+    if np.all((weights >= min_weights) & (weights <= max_weights)):
+        return weights
+
+    if solver_params is None:
+        solver_params = {}
+
+    n = len(weights)
+    w = cp.Variable(n)
+
+    objective = cp.Minimize(cp.norm(w / weights - 1))
+    constraints = [cp.sum(w) == 1, w >= min_weights, w <= max_weights]
+    problem = cp.Problem(objective, constraints)
+
+    try:
+        problem.solve(solver=solver, **solver_params)
+
+        if w.value is None:
+            raise cp.SolverError("No solution found")
+
+    except (cp.SolverError, scl.ArpackNoConvergence):
+        raise cp.SolverError(
+            f"Solver '{solver}' failed. Try another"
+            " solver, or solve with solver_params=dict(verbose=True) for more"
+            " information"
+        ) from None
+
+    return w.value

--- a/tests/test_optimization/test_cluster/test_hierarchical/test_herc.py
+++ b/tests/test_optimization/test_cluster/test_hierarchical/test_herc.py
@@ -11,7 +11,11 @@ from skfolio.prior import EmpiricalPrior, FactorModel
 
 @pytest.fixture(
     scope="module",
-    params=list(RiskMeasure) + list(ExtraRiskMeasure),
+    params=[
+        x
+        for x in [*RiskMeasure, *ExtraRiskMeasure]
+        if x not in [ExtraRiskMeasure.SKEW, ExtraRiskMeasure.KURTOSIS]
+    ],
 )
 def risk_measure(request):
     return request.param
@@ -149,3 +153,76 @@ def test_metadata_routing(X_medium, implied_vol_medium):
 
     # noinspection PyUnresolvedReferences
     assert model.prior_estimator_.covariance_estimator_.r2_scores_.shape == (20,)
+
+
+def test_herc_weight_constraints(X):
+    model = HierarchicalEqualRiskContribution(
+        risk_measure=RiskMeasure.STANDARD_DEVIATION,
+    )
+    model.fit(X)
+    np.testing.assert_almost_equal(model.weights_[0], 0.02584786935368332)
+    np.testing.assert_almost_equal(model.weights_[-1], 0.0421175871045949)
+    np.testing.assert_almost_equal(sum(model.weights_), 1.0)
+
+    # Min Weights
+    model.set_params(min_weights={"AAPL": 0.05, "XOM": 0.08})
+    model.fit(X)
+    np.testing.assert_almost_equal(model.weights_[0], 0.05)
+    np.testing.assert_almost_equal(model.weights_[-1], 0.08)
+    np.testing.assert_almost_equal(sum(model.weights_), 1.0)
+
+    model.set_params(min_weights=0.05)
+    model.fit(X)
+    np.testing.assert_almost_equal(model.weights_, np.ones(20) * 0.05)
+    np.testing.assert_almost_equal(sum(model.weights_), 1.0)
+
+    # Max Weights
+    model.set_params(min_weights=0)
+    model.set_params(max_weights={"AAPL": 0.01, "XOM": 0.03})
+    model.fit(X)
+    np.testing.assert_almost_equal(model.weights_[0], 0.01)
+    np.testing.assert_almost_equal(model.weights_[-1], 0.03)
+    np.testing.assert_almost_equal(sum(model.weights_), 1.0)
+
+    model.set_params(max_weights=0.05)
+    model.fit(X)
+    np.testing.assert_almost_equal(model.weights_, np.ones(20) * 0.05)
+    np.testing.assert_almost_equal(sum(model.weights_), 1.0)
+
+    # Both
+    model.set_params(min_weights={"AAPL": 0.05}, max_weights={"XOM": 0.03})
+    model.fit(X)
+    np.testing.assert_almost_equal(model.weights_[0], 0.05)
+    np.testing.assert_almost_equal(model.weights_[-1], 0.03)
+    np.testing.assert_almost_equal(sum(model.weights_), 1.0)
+
+    model.set_params(min_weights=0.03, max_weights=0.06)
+    model.fit(X)
+    np.testing.assert_almost_equal(
+        model.weights_,
+        np.array(
+            [
+                0.03218923,
+                0.05585784,
+                0.06,
+                0.03,
+                0.05336249,
+                0.06,
+                0.04001747,
+                0.05895233,
+                0.06,
+                0.06,
+                0.03674032,
+                0.04708938,
+                0.03484055,
+                0.06,
+                0.04486381,
+                0.06,
+                0.05002204,
+                0.03796618,
+                0.05914401,
+                0.05895433,
+            ]
+        ),
+    )
+    np.testing.assert_almost_equal(sum(model.weights_), 1.0)

--- a/tests/test_optimization/test_cluster/test_hierarchical/test_hrp.py
+++ b/tests/test_optimization/test_cluster/test_hierarchical/test_hrp.py
@@ -16,7 +16,11 @@ def small_X(X):
 
 @pytest.fixture(
     scope="module",
-    params=list(RiskMeasure) + list(ExtraRiskMeasure),
+    params=[
+        x
+        for x in [*RiskMeasure, *ExtraRiskMeasure]
+        if x not in [ExtraRiskMeasure.SKEW, ExtraRiskMeasure.KURTOSIS]
+    ],
 )
 def risk_measure(request):
     return request.param

--- a/tests/test_optimization/test_cluster/test_hierarchical/test_hrp.py
+++ b/tests/test_optimization/test_cluster/test_hierarchical/test_hrp.py
@@ -173,3 +173,76 @@ def test_metadata_routing(X_medium, implied_vol_medium):
 
     # noinspection PyUnresolvedReferences
     assert model.prior_estimator_.covariance_estimator_.r2_scores_.shape == (20,)
+
+
+def test_hrp_weight_constraints(X):
+    model = HierarchicalRiskParity(
+        risk_measure=RiskMeasure.STANDARD_DEVIATION,
+    )
+    model.fit(X)
+    np.testing.assert_almost_equal(model.weights_[0], 0.030624328591088226)
+    np.testing.assert_almost_equal(model.weights_[-1], 0.05811358822991056)
+    np.testing.assert_almost_equal(sum(model.weights_), 1.0)
+
+    # Min Weights
+    model.set_params(min_weights={"AAPL": 0.05, "XOM": 0.08})
+    model.fit(X)
+    np.testing.assert_almost_equal(model.weights_[0], 0.05)
+    np.testing.assert_almost_equal(model.weights_[-1], 0.08)
+    np.testing.assert_almost_equal(sum(model.weights_), 1.0)
+
+    model.set_params(min_weights=0.05)
+    model.fit(X)
+    np.testing.assert_almost_equal(model.weights_, np.ones(20) * 0.05)
+    np.testing.assert_almost_equal(sum(model.weights_), 1.0)
+
+    # Max Weights
+    model.set_params(min_weights=0)
+    model.set_params(max_weights={"AAPL": 0.01, "XOM": 0.03})
+    model.fit(X)
+    np.testing.assert_almost_equal(model.weights_[0], 0.01)
+    np.testing.assert_almost_equal(model.weights_[-1], 0.03)
+    np.testing.assert_almost_equal(sum(model.weights_), 1.0)
+
+    model.set_params(max_weights=0.05)
+    model.fit(X)
+    np.testing.assert_almost_equal(model.weights_, np.ones(20) * 0.05)
+    np.testing.assert_almost_equal(sum(model.weights_), 1.0)
+
+    # Both
+    model.set_params(min_weights={"AAPL": 0.05}, max_weights={"XOM": 0.03})
+    model.fit(X)
+    np.testing.assert_almost_equal(model.weights_[0], 0.05)
+    np.testing.assert_almost_equal(model.weights_[-1], 0.03)
+    np.testing.assert_almost_equal(sum(model.weights_), 1.0)
+
+    model.set_params(min_weights=0.03, max_weights=0.06)
+    model.fit(X)
+    np.testing.assert_almost_equal(
+        model.weights_,
+        np.array(
+            [
+                0.03,
+                0.03,
+                0.03,
+                0.04712633,
+                0.05191067,
+                0.06,
+                0.06,
+                0.06,
+                0.03,
+                0.06,
+                0.06,
+                0.06,
+                0.04068081,
+                0.06,
+                0.05825588,
+                0.06,
+                0.03115588,
+                0.05087043,
+                0.06,
+                0.06,
+            ]
+        ),
+    )
+    np.testing.assert_almost_equal(sum(model.weights_), 1.0)


### PR DESCRIPTION
<!--
Welcome to skfolio, and thanks for contributing!
-->

#### Reference Issues/PRs
 Fixes #91


#### What does this implement/fix? Explain your changes.

Weight constraints in HERC didn't work as intended.

The initial paper does not provide an algorithm for handling weight
constraints, and no standard solution currently exists.

In contrast to HRP (Hierarchical Risk Parity), where weight constraints
can be applied to the split factor at each bisection step, HERC
(Hierarchical Equal Risk Contribution) cannot incorporate weight constraints
during the intermediate steps of the allocation. Therefore, in HERC, the
weight constraints must be enforced after the top-down allocation has been
completed.

To do it, we minimize the relative deviation of the final weights from
the initial weights. This is formulated as a convex optimization problem.

#### Does your contribution introduce a new dependency? If yes, which one?
No

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

#### Did you add any tests for the change?
Yes

#### Any other comments?
<!--
We value all user contributions, no matter how small or complex they are. Please feel free to any additional comments.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.
- [ ] Optionally, I've added myself and possibly others to the [CODEOWNERS](https://github.com/skfolio/skfolio/blob/main/CODEOWNERS) file - do this if you want to become the owner or maintainer of an estimator you added.

##### For new estimators
- [ ] I've added the estimator to the API reference in `docs/api.rst`.
- [ ] I've added one or more illustrative usage examples to the docstring and the `examples` section.

<!--
Thanks for contributing!
-->