### PR TITLE
[MNT] Pin `kaleido==0.2.1` version to fix `sphinx-build`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ docs = [
     "sphinx-design",
     "pydata-sphinx-theme==0.13.3",
     "matplotlib",
-    "kaleido",
+    "kaleido==0.2.1",
     "sphinx-copybutton",
     "numpydoc",
     "sphinx-togglebutton",


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.

The documentation site is built using Sphinx, in turn making use of `plotly_sg_scraper` under the hood to render plot images, which itself in turn depends on [kaleido](https://pypi.org/project/kaleido/). `kaleido 0.4.1` got released recently (on Nov 15, 2024) introducing some changes under the hood causing the `sphinx-build . _build` command to run indefinitely.

This PR pins the version of `kaleido` to `0.2.1`, the version that has been resolved by the dependency graph prior to Nov 15, 2024.

#### Does your contribution introduce a new dependency? If yes, which one?

N/A
#### What should a reviewer concentrate their feedback on?

The `Deploy Documentation` GitHub workflow should keep working as expected.

#### Did you add any tests for the change?

N/A

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions

- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.
- [ ] Optionally, I've added myself and possibly others to the [CODEOWNERS](https://github.com/skfolio/skfolio/blob/main/CODEOWNERS) file - do this if you want to become the owner or maintainer of an estimator you added.

##### For new estimators

N/A

<!--
Thanks for contributing!
-->