### PR TITLE
[MNT] Specify `environment` in docs flow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,6 +16,9 @@ jobs:
       contents: read
       pages: write
       id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.gh_pages_deployment.outputs.page_url }}
     concurrency: release
 
     steps:


### PR DESCRIPTION
#### Reference Issues/PRs

Follow-up of #98.


#### What does this implement/fix? Explain your changes.

Specifies the GitHub pages `environment` key in the docs deployment flow.

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.
- [ ] Optionally, I've added myself and possibly others to the [CODEOWNERS](https://github.com/skfolio/skfolio/blob/main/CODEOWNERS) file - do this if you want to become the owner or maintainer of an estimator you added.