### PR TITLE
[BUG] Use CORS proxy to load remote datasets from browser

### DIFF
--- a/src/skfolio/datasets/_base.py
+++ b/src/skfolio/datasets/_base.py
@@ -9,9 +9,9 @@
 # Grisel Licensed under BSD 3 clause.
 
 import gzip
-import sys
 import os
 import shutil
+import sys
 import urllib.request as ur
 from importlib import resources
 from pathlib import Path
@@ -141,9 +141,9 @@ def download_dataset(
         DataFrame with each row representing one observation and each column
         representing the asset price of a given observation.
     """
-    url = (
-        # Use a CORS proxy when triggering requests from the browser
-        "https://corsproxy.io/?" if sys.platform == "emscripten" else ""
+    # Use a CORS proxy when triggering requests from the browser
+    url_prefix = "https://corsproxy.io/?" if sys.platform == "emscripten" else ""
+    url = url_prefix + (
         f"https://github.com/skfolio/skfolio-datasets/raw/main/"
         f"datasets/{data_filename}.csv.gz"
     )

--- a/src/skfolio/datasets/_base.py
+++ b/src/skfolio/datasets/_base.py
@@ -9,6 +9,7 @@
 # Grisel Licensed under BSD 3 clause.
 
 import gzip
+import sys
 import os
 import shutil
 import urllib.request as ur
@@ -141,6 +142,8 @@ def download_dataset(
         representing the asset price of a given observation.
     """
     url = (
+        # Use a CORS proxy when triggering requests from the browser
+        "https://corsproxy.io/?" if sys.platform == "emscripten" else ""
         f"https://github.com/skfolio/skfolio-datasets/raw/main/"
         f"datasets/{data_filename}.csv.gz"
     )


### PR DESCRIPTION
#### Reference Issues/PRs

Related to #98

#### What does this implement/fix? Explain your changes.

When in an `emscripten` environment (JupyterLite) we need to work around CORS issues when requesting datasets from https://github.com/skfolio/skfolio-datasets/raw/main/.

See the related discussion here: https://github.com/skfolio/skfolio/pull/98#issuecomment-2481587348.

#### Any other comments?

> [!IMPORTANT]  
> These changes will only take effect once a new release is deployed to PyPI and the `await piplite.install(['skfolio'], deps=False)` command in JupyterLite notebooks will actually pull a wheel that contains *these* changes.

#### PR checklist

##### For all contributions
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.
- [ ] Optionally, I've added myself and possibly others to the [CODEOWNERS](https://github.com/skfolio/skfolio/blob/main/CODEOWNERS) file - do this if you want to become the owner or maintainer of an estimator you added.

##### For new estimators
- [ ] I've added the estimator to the API reference in `docs/api.rst`.
- [ ] I've added one or more illustrative usage examples to the docstring and the `examples` section.

<!--
Thanks for contributing!
-->