### PR TITLE
[ENH] Dockerfile integration to jupyterlab locally with skfolio installed and working

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+*/__pycache__
+*/*.pyc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,47 @@
+# Use a Python image with uv pre-installed
+FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
+
+# Install the project into `/app`
+WORKDIR /app
+
+# Enable bytecode compilation
+ENV UV_COMPILE_BYTECODE=1
+
+# Copy from the cache instead of linking since it's a mounted volume
+ENV UV_LINK_MODE=copy
+
+# Install the project's dependencies using the lockfile and settings
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=uv.lock,target=uv.lock \
+    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
+    uv sync --frozen --no-install-project --no-dev
+
+
+# Then, add the rest of the project source code and install it
+# Installing separately from its dependencies allows optimal layer caching
+ADD . /app
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-dev
+
+# Additionally install the jupyterlab extension
+
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv add jupyterlab ipywidgets
+
+# Verify Jupyter is installed and in PATH
+RUN which jupyter || echo "Jupyter not found in PATH"
+
+    # Place executables in the environment at the front of the path
+ENV PATH="/app/.venv/bin:$PATH"
+
+# Reset the entrypoint, don't invoke `uv`
+ENTRYPOINT []
+EXPOSE 8888
+
+# Enter the examples directory
+# Default command to start JupyterLab (using JSON array format)
+CMD ["jupyter","lab", "--ip=0.0.0.0", "--port=8888", "--no-browser", "--allow-root", "--NotebookApp.token=''", "--NotebookApp.password=''"]
+
+# How to build and run the image
+# docker build -t skfolio-jupyterlab .
+# docker run -p 8888:8888 -v <path-to-your-folder-containing-data>:/app/data -it skfolio


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
This PR introduces Docker integration. The user can run skfolio in a dedicated container and experiment with jupyterlab autonomously, so that new users can avoid having installation problems.

The pyproject.toml is untoucher and installation of jupyterlab is done in a separate stage using uv.
The jupyterlab service is span at `localhost:8888/lab`.
Additional local folders (for example those containing datasets) can be mounted as option to the `-v` parameter of Docker.

Each user having a Docker desktop or a server docker installation can build and run skfolio with a jupyterlab interface like this:

```bash
docker build -t skfolio-jupyterlab .
docker run -p 8888:8888 -v <path-to-your-folder-containing-data>:/app/data -it skfolio
```

#### Does your contribution introduce a new dependency? If yes, which one?
Only docker, but is not a dependency.

#### What should a reviewer concentrate their feedback on?
A reviewer should take a look at the docker and the instructions.

#### Did you add any tests for the change?
No.
#### Any other comments?
No