### PR TITLE
[ENH] add DropZeroVariance

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
     hooks:
       - id: ruff
         name: ruff-lint
-        args: [check, --fix, --exit-non-zero-on-fix]
+        args: [--fix, --exit-non-zero-on-fix]
       - id: ruff
         name: ruff-format
         args: [format, --diff]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,6 @@
 
 * fix(population): surface plot compatible with plotly v6.0 ([`c053625`](https://github.com/skfolio/skfolio/commit/c053625d641eda1deee480aafd8d10cd0e6b3c56))
 
-### Feature
-
-* feat: DropZeroVariance estimator
-
 ## v0.8.0 (2025-03-21)
 
 ### Breaking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * fix(population): surface plot compatible with plotly v6.0 ([`c053625`](https://github.com/skfolio/skfolio/commit/c053625d641eda1deee480aafd8d10cd0e6b3c56))
 
+### Feature
+
+* feat: DropZeroVariance estimator
+
 ## v0.8.0 (2025-03-21)
 
 ### Breaking

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -491,6 +491,7 @@ Classes
     :template: class.rst
 
     pre_selection.DropCorrelated
+    pre_selection.DropZeroVariance
     pre_selection.SelectKExtremes
     pre_selection.SelectNonDominated
     pre_selection.SelectComplete

--- a/docs/user_guide/pre_selection.rst
+++ b/docs/user_guide/pre_selection.rst
@@ -16,6 +16,7 @@ It follows the same API as scikit-learn's `estimator`: the `fit_transform` metho
 
 
 Available transformers are:
+    * :class:`DropZeroVariance`
     * :class:`DropCorrelated`
     * :class:`SelectKExtremes`
     * :class:`SelectNonDominated`

--- a/examples/8_pre_selection/plot_1_drop_correlated.py
+++ b/examples/8_pre_selection/plot_1_drop_correlated.py
@@ -31,7 +31,7 @@ from skfolio.model_selection import (
     optimal_folds_number,
 )
 from skfolio.optimization import MeanRisk, ObjectiveFunction
-from skfolio.pre_selection import DropCorrelated
+from skfolio.pre_selection import DropCorrelated, DropZeroVariance
 from skfolio.preprocessing import prices_to_returns
 
 prices = load_ftse100_dataset()
@@ -57,7 +57,8 @@ set_config(transform_output="pandas")
 
 model2 = Pipeline(
     [
-        ("pre_selection", DropCorrelated(threshold=0.5)),
+        ("drop_zero_variance", DropZeroVariance(threshold=1e-6)),
+        ("drop_correlated", DropCorrelated(threshold=0.5)),
         ("optimization", MeanRisk(objective_function=ObjectiveFunction.MAXIMIZE_RATIO)),
     ]
 )

--- a/src/skfolio/pre_selection/__init__.py
+++ b/src/skfolio/pre_selection/__init__.py
@@ -1,6 +1,7 @@
 """Pre Selection module."""
 
 from skfolio.pre_selection._drop_correlated import DropCorrelated
+from skfolio.pre_selection._drop_zero_variance import DropZeroVariance
 from skfolio.pre_selection._select_complete import SelectComplete
 from skfolio.pre_selection._select_k_extremes import SelectKExtremes
 from skfolio.pre_selection._select_non_dominated import SelectNonDominated
@@ -8,6 +9,7 @@ from skfolio.pre_selection._select_non_expiring import SelectNonExpiring
 
 __all__ = [
     "DropCorrelated",
+    "DropZeroVariance",
     "SelectComplete",
     "SelectKExtremes",
     "SelectNonDominated",

--- a/src/skfolio/pre_selection/_drop_zero_variance.py
+++ b/src/skfolio/pre_selection/_drop_zero_variance.py
@@ -1,0 +1,68 @@
+"""Pre-selection DropZeroVariance module."""
+
+import numpy as np
+import numpy.typing as npt
+import sklearn.base as skb
+import sklearn.feature_selection as skf
+import sklearn.utils.validation as skv
+
+
+class DropZeroVariance(skf.SelectorMixin, skb.BaseEstimator):
+    """Transformer for dropping assets with near-zero variance.
+
+    On short windows, some assets can experience a near-zero variance, making
+    the covariance matrix improper for optimization. This simple transformer drops
+    assets whose variance is below some threshold.
+
+    Parameters
+    ----------
+    threshold : float, default=1e-6
+        Correlation threshold. The default value is `1e-6`.
+
+    Attributes
+    ----------
+    to_keep_ : ndarray of shape (n_assets, )
+        Boolean array indicating which assets are remaining.
+
+    n_features_in_ : int
+        Number of assets seen during `fit`.
+
+    feature_names_in_ : ndarray of shape (`n_features_in_`,)
+        Names of assets seen during `fit`. Defined only when `X`
+        has assets names that are all strings.
+    """
+
+    to_keep_: np.ndarray
+
+    def __init__(self, threshold: float = 1e-6):
+        self.threshold = threshold
+
+    def fit(self, X: npt.ArrayLike, y=None):
+        """Fit the transformer on some assets.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_observations, n_assets)
+            Price returns of the assets.
+
+        y : Ignored
+            Not used, present for API consistency by convention.
+
+        Returns
+        -------
+        self : DropZeroVariance
+            Fitted estimator.
+        """
+        X = skv.validate_data(self, X)
+        if self.threshold < 0:
+            raise ValueError(
+                f"`threshold` must be higher than 0, got {self.threshold}."
+            )
+
+        self.to_keep_ = X.var(axis=0) > self.threshold
+
+        return self
+
+    def _get_support_mask(self):
+        skv.check_is_fitted(self)
+        return self.to_keep_

--- a/src/skfolio/pre_selection/_drop_zero_variance.py
+++ b/src/skfolio/pre_selection/_drop_zero_variance.py
@@ -17,7 +17,7 @@ class DropZeroVariance(skf.SelectorMixin, skb.BaseEstimator):
     Parameters
     ----------
     threshold : float, default=1e-6
-        Correlation threshold. The default value is `1e-6`.
+        Minimum variance threshold. The default value is `1e-6`.
 
     Attributes
     ----------

--- a/src/skfolio/pre_selection/_drop_zero_variance.py
+++ b/src/skfolio/pre_selection/_drop_zero_variance.py
@@ -1,5 +1,9 @@
 """Pre-selection DropZeroVariance module."""
 
+# Copyright (c) 2025
+# Author: Vincent Maladiere <maladiere.vincent@gmail.com>
+# SPDX-License-Identifier: BSD-3-Clause
+
 import numpy as np
 import numpy.typing as npt
 import sklearn.base as skb
@@ -16,8 +20,11 @@ class DropZeroVariance(skf.SelectorMixin, skb.BaseEstimator):
 
     Parameters
     ----------
-    threshold : float, default=1e-6
-        Minimum variance threshold. The default value is `1e-6`.
+    threshold : float, default=1e-8
+        Minimum variance threshold. The default value is 1e-8. For daily asset returns,
+        this value filters out assets whose daily standard deviation is below 1e-4
+        (0.01%), which corresponds to an annual standard deviation of approximately
+        0.16%, assuming 252 trading days.
 
     Attributes
     ----------
@@ -34,7 +41,7 @@ class DropZeroVariance(skf.SelectorMixin, skb.BaseEstimator):
 
     to_keep_: np.ndarray
 
-    def __init__(self, threshold: float = 1e-6):
+    def __init__(self, threshold: float = 1e-8):
         self.threshold = threshold
 
     def fit(self, X: npt.ArrayLike, y=None):

--- a/tests/test_pipeline/test_pipeline.py
+++ b/tests/test_pipeline/test_pipeline.py
@@ -1,3 +1,4 @@
+import pytest
 from sklearn import config_context, set_config
 from sklearn.model_selection import train_test_split
 from sklearn.pipeline import Pipeline
@@ -6,38 +7,30 @@ from skfolio.moments import (
     ImpliedCovariance,
 )
 from skfolio.optimization import InverseVolatility, MeanRisk
-from skfolio.pre_selection import DropCorrelated, SelectKExtremes, SelectNonDominated
+from skfolio.pre_selection import (
+    DropCorrelated,
+    DropZeroVariance,
+    SelectKExtremes,
+    SelectNonDominated,
+)
 from skfolio.prior import EmpiricalPrior
 
 
-def test_transformer(X):
+@pytest.mark.parametrize(
+    "transformer",
+    [
+        DropCorrelated(threshold=0.9),
+        DropZeroVariance(threshold=1e-6),
+        SelectNonDominated(min_n_assets=15, threshold=0),
+        SelectKExtremes(k=10, highest=True),
+    ],
+)
+def test_transformer(X, transformer):
     set_config(transform_output="pandas")
 
     X_train, X_test = train_test_split(X, shuffle=False, test_size=0.3)
 
-    pipe = Pipeline(
-        [("pre_selection", DropCorrelated(threshold=0.9)), ("mean_risk", MeanRisk())]
-    )
-    pipe.fit(X_train)
-    portfolio = pipe.predict(X_test)
-    _ = portfolio.sharpe_ratio
-
-    pipe = Pipeline(
-        [
-            ("pre_selection", SelectNonDominated(min_n_assets=15, threshold=0)),
-            ("mean_risk", MeanRisk()),
-        ]
-    )
-    pipe.fit(X_train)
-    portfolio = pipe.predict(X_test)
-    _ = portfolio.sharpe_ratio
-
-    pipe = Pipeline(
-        [
-            ("pre_selection", SelectKExtremes(k=10, highest=True)),
-            ("optimization", MeanRisk()),
-        ]
-    )
+    pipe = Pipeline([("pre_selection", transformer), ("mean_risk", MeanRisk())])
     pipe.fit(X_train)
     portfolio = pipe.predict(X_test)
     _ = portfolio.sharpe_ratio

--- a/tests/test_pre_selection/test_drop_zero_variance.py
+++ b/tests/test_pre_selection/test_drop_zero_variance.py
@@ -1,4 +1,3 @@
-# ruff: noqa
 import pandas as pd
 from pandas.testing import assert_frame_equal
 

--- a/tests/test_pre_selection/test_drop_zero_variance.py
+++ b/tests/test_pre_selection/test_drop_zero_variance.py
@@ -1,3 +1,4 @@
+# ruff: noqa
 import pandas as pd
 from pandas.testing import assert_frame_equal
 
@@ -5,7 +6,6 @@ from skfolio.pre_selection import DropZeroVariance
 
 
 def test_drop_zero_variance():
-
     X = pd.DataFrame(dict(a=[1, 1, 1], b=[1, 2, 3]))
 
     transformer = DropZeroVariance().set_output(transform="pandas")

--- a/tests/test_pre_selection/test_drop_zero_variance.py
+++ b/tests/test_pre_selection/test_drop_zero_variance.py
@@ -1,0 +1,13 @@
+import pandas as pd
+from pandas.testing import assert_frame_equal
+
+from skfolio.pre_selection import DropZeroVariance
+
+
+def test_drop_zero_variance():
+
+    X = pd.DataFrame(dict(a=[1, 1, 1], b=[1, 2, 3]))
+
+    transformer = DropZeroVariance().set_output(transform="pandas")
+    Xt = transformer.fit_transform(X)
+    assert_frame_equal(Xt, X[["b"]])

--- a/tests/test_pre_selection/test_drop_zero_variance.py
+++ b/tests/test_pre_selection/test_drop_zero_variance.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import pytest
 from pandas.testing import assert_frame_equal
 
 from skfolio.pre_selection import DropZeroVariance
@@ -10,3 +11,10 @@ def test_drop_zero_variance():
     transformer = DropZeroVariance().set_output(transform="pandas")
     Xt = transformer.fit_transform(X)
     assert_frame_equal(Xt, X[["b"]])
+
+
+def test_wrong_threshold():
+    X = pd.DataFrame(dict(a=[1, 1, 1], b=[1, 2, 3]))
+    transformer = DropZeroVariance(threshold=-1)
+    with pytest.raises(ValueError, match="higher than 0"):
+        transformer.fit(X)


### PR DESCRIPTION
<!--
Welcome to skfolio, and thanks for contributing!
-->

This is my first PR with skfolio! :)

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests.
If no issue exists, you can open one here: https://github.com/skfolio/skfolio/issues
-->
Fixes https://github.com/skfolio/skfolio/issues/131

#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->
A simple `DropZeroVariance` transformer to drop assets with near-zero variance.

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
Only relevant if you changed pyproject.toml.
We try to minimize dependencies in the core dependency set.
-->
No

#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

#### Did you add any tests for the change?

<!-- This section is useful if you have added a test in addition to the existing ones. This will ensure that further changes to these files won't introduce the same kind of bug. It is considered good practice to add tests with newly added code to enforce the fact that the code actually works. This will reduce the chance of introducing logical bugs.
-->
Yes

#### Any other comments?
<!--
We value all user contributions, no matter how small or complex they are. Please feel free to any additional comments.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG]. [BUG] - bugfix, [MNT] - CI, test framework, [ENH] - adding or improving code, [DOC] - writing or improving documentation or docstrings.
- [ ] Optionally, I've added myself and possibly others to the [CODEOWNERS](https://github.com/skfolio/skfolio/blob/main/CODEOWNERS) file - do this if you want to become the owner or maintainer of an estimator you added.
	-> this file doesn't exist anymore, should we remove this entry in the PR template?

##### For new estimators
- [x] I've added the estimator to the API reference in `docs/api.rst`.
- [x] I've added one or more illustrative usage examples to the docstring and the `examples` section.

<!--
Thanks for contributing!
-->