### PR TITLE
 [ENH] Failure handling and fallbacks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,3 +146,6 @@ sphinx_gallery/tests/tinybuild/auto_examples/
 sphinx_gallery/tests/tinybuild/_build/
 sphinx_gallery/tests/tinybuild/tiny_html/
 junit-results.xml
+
+# Cursor editor workspace
+.cursor/

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -126,6 +126,7 @@ Classes
     :template: class.rst
 
     portfolio.Portfolio
+    portfolio.FailedPortfolio
     portfolio.MultiPeriodPortfolio
 
 
@@ -149,6 +150,26 @@ Classes
 
     population.Population
 
+
+.. _optimization_base_ref:
+
+:mod:`skfolio.optimization.base`: Base Optimization Estimator
+=============================================================
+
+.. automodule:: skfolio.optimization
+   :no-members:
+   :no-inherited-members:
+
+Classes
+-------
+.. currentmodule:: skfolio
+
+.. autosummary::
+    :nosignatures:
+    :toctree: generated/
+    :template: class.rst
+
+    optimization.BaseOptimization
 
 .. _optimization_naive_ref:
 

--- a/examples/mean_risk/plot_17_failure_and_fallbacks.py
+++ b/examples/mean_risk/plot_17_failure_and_fallbacks.py
@@ -1,0 +1,264 @@
+"""
+=====================
+Failure and Fallbacks
+=====================
+
+This tutorial introduces the optimization parameters `fallback` and `raise_on_failure`.
+
+Optimization can sometimes fail during a given rebalancing. For example, a convex
+mean-variance problem with strict risk or sector constraints may become infeasible on
+specific dates. Such failures must be handled explicitly depending on the use case
+(production vs. research).
+
+Fallback
+========
+The `fallback` parameter lets you define an estimator, or a list of estimators, to try
+in order when the primary optimization raises an error during `fit`. Alternatively, you
+can use `"previous_weights"` to reuse the last valid allocation.
+
+Each attempt is recorded in `fallback_chain_`, and the successful estimator is available
+through `fallback_`.
+
+This mechanism is critical in automated production, where optimization failures
+shouldn't interrupt pipelines and where you need reproducibility and auditability.
+It can also be used to loosen optimization constraints gradually.
+
+Raise on Failure
+================
+In research, cross-validation and hyperparameter tuning (e.g., walk-forward, multiple
+randomized cross-validation), it's often useful to let all runs complete while keeping
+a full record of failures instead of stopping on the first failed rebalancing.
+
+- Set `raise_on_failure=True` (default) to fail fast. This is useful in production when
+  the primary optimization or the fallback cascade is expected to succeed.
+
+- Set `raise_on_failure=False` to continue uninterrupted. This is useful in research
+  and cross-validation. When a failure occurs, `predict` returns a
+  :class:`~skfolio.portfolio.FailedPortfolio` (think of it as an augmented NaN) that
+  carries diagnostics such as `optimization_error` and `fallback_chain`, while remaining
+  API-compatible with downstream analytics.
+
+"""
+
+# %%
+# Data and Setup
+# ==============
+# Load the S&P 500 :ref:`dataset <datasets>` and split into train/test.
+import numpy as np
+from numpy.typing import ArrayLike
+from plotly.io import show
+from sklearn.model_selection import train_test_split
+from sklearn.utils.validation import validate_data
+
+from skfolio.datasets import load_sp500_dataset
+from skfolio.model_selection import WalkForward, cross_val_predict
+from skfolio.optimization import BaseOptimization, EqualWeighted, MeanRisk
+from skfolio.preprocessing import prices_to_returns
+from skfolio.typing import Fallback, MultiInput
+from skfolio.utils.stats import rand_weights
+
+# Load S&P 500 dataset and split train/test
+prices = load_sp500_dataset()
+prices = prices["2010":]
+X = prices_to_returns(prices)
+X_train, X_test = train_test_split(X, test_size=0.33, shuffle=False)
+
+
+# %%
+# Fallback
+# ========
+# Let's start with a simple example.
+# The primary model is a minimum-variance optimization made intentionally infeasible
+# (the assets' minimum weights are set to 10%, which exceeds the feasible upper bound
+# of 1/n_assets = 5%). As a fallback, we provide a feasible minimum-variance model
+# with a 2% minimum weight constraint:
+model = MeanRisk(
+    min_weights=0.1,  # intentionally infeasible
+    fallback=MeanRisk(min_weights=0.02),  # feasible fallback
+)
+model.fit(X_train)
+print(model.weights_)
+
+# %%
+# Diagnostics
+# -----------
+# Let's retrieve the fitted fallback that produced the final result:
+print(model.fallback_)
+
+# %%
+# Let's display the sequence of attempts and their outcomes:
+print(model.fallback_chain_)
+
+# %%
+# The fallback audit trail is also propagated to the predicted portfolio:
+portfolio = model.predict(X_test)
+assert portfolio.fallback_chain == model.fallback_chain_
+
+
+# %%
+# Multiple fallbacks
+# ------------------
+# We can also provide a list of fallbacks to be tried in order, including
+# "previous_weights" as a terminal safety net:
+model = MeanRisk(
+    min_weights=0.1,
+    previous_weights={
+        "AAPL": 0.4,
+        "AMD": 0.2,
+        "UNH": 0.4,
+    },  # any missing assets default to 0
+    fallback=[
+        MeanRisk(min_weights=0.02),
+        MeanRisk(min_weights=0.01),
+        EqualWeighted(),
+        "previous_weights",
+    ],
+)
+
+# %%
+# Chaining
+# --------
+# We can also nest fallbacks.
+# The chain is evaluated depth-first from the primary estimator to the
+# first successful fallback, recording each attempt in `fallback_chain_`.
+# This is equivalent to providing an ordered list:
+model = MeanRisk(
+    min_weights=0.1,
+    fallback=MeanRisk(
+        min_weights=0.02,
+        fallback=MeanRisk(
+            min_weights=0.01,
+            fallback=EqualWeighted(),
+        ),
+    ),
+)
+
+# %%
+# Fallback in cross-validation
+# ============================
+# Fallback behavior is fully preserved in cross-validation.
+#
+# When using `cross_val_predict`, all diagnostics (e.g., fallback chains and errors)
+# are propagated to the resulting portfolios in the `MultiPeriodPortfolio`:
+#
+# - Each individual :class:`~skfolio.portfolio.Portfolio`
+#   (or :class:`~skfolio.portfolio.FailedPortfolio`) produced during rebalancing
+#   carries its own `fallback_chain` and `optimization_error`.
+# - Global counts and statistics (e.g., the number of portfolios that required a
+#   fallback) are available through summary attributes such as
+#   `n_fallback_portfolios` and `n_failed_portfolios`.
+# - The `summary()` method consolidates performance and diagnostic information
+#   across all rebalances.
+model = MeanRisk(min_weights=0.1, fallback=MeanRisk(min_weights=0.02))
+
+# Rebalance semiannually on the third Friday (WOM-3FRI), training on the prior 12 months
+walk_forward = WalkForward(test_size=6, train_size=12, freq="WOM-3FRI")
+
+pred = cross_val_predict(model, X, cv=walk_forward)
+
+# %%
+# Let's retrieve the fallback chain of the first portfolio:
+print(pred[0].fallback_chain)
+
+# %%
+# Let's print the number of portfolios in
+# :class:`~skfolio.portfolio.MultiPeriodPortfolio` where a fallback was used:
+print(pred.n_fallback_portfolios)
+
+# %%
+# Finally, let's display the last four rows of the `MultiPeriodPortfolio` summary,
+# which contain the fallback statistics:
+print(pred.summary().iloc[-4:])
+
+
+# %%
+# Failure handling
+# ================
+# In this section, we show how to handle optimization failures using the
+# `raise_on_failure` parameter.
+# As an example, we create a custom optimization that fails randomly
+# with probability `failure_proba`:
+class CustomOptimization(BaseOptimization):
+    """Dummy optimization that forces a `fit` failure with proba `failure_proba`."""
+
+    def __init__(
+        self,
+        failure_proba: float = 0.5,
+        portfolio_params: dict | None = None,
+        fallback: Fallback = None,
+        previous_weights: MultiInput | None = None,
+        raise_on_failure: bool = True,
+    ):
+        super().__init__(
+            portfolio_params=portfolio_params,
+            fallback=fallback,
+            raise_on_failure=raise_on_failure,
+            previous_weights=previous_weights,
+        )
+        self.failure_proba = failure_proba
+
+    def fit(self, X: ArrayLike, y=None):
+        X = validate_data(self, X)
+        # Fail with probability equal to `failure_proba`
+        if np.random.rand() < self.failure_proba:
+            raise RuntimeError("Forced failure")
+        n_assets = X.shape[1]
+        self.weights_ = rand_weights(n_assets)
+        return self
+
+
+# %%
+# By default, as with all scikit-learn estimators, failures raise an error during `fit`:
+model = CustomOptimization(failure_proba=1.0)
+try:
+    model.fit(X_train)
+except RuntimeError as err:
+    print(err)
+
+
+# %%
+# By setting `raise_on_failure=False`, a warning is emitted instead of raising an error,
+# and `weights_` are set to `None`, with the error message stored in `error_`:
+model = CustomOptimization(failure_proba=1.0, raise_on_failure=False)
+model.fit(X_train)
+print(model.weights_)
+print(model.error_)
+
+# %%
+# In this case, calling `predict` will return a `FailedPortfolio` carrying the audit
+# trail in `optimization_error` and `fallback_chain` (if any fallbacks occurred).
+portfolio = model.predict(X_test)
+print(portfolio)
+print(portfolio.optimization_error)
+
+# %%
+# Setting `raise_on_failure=False` is useful for cross-validation and hyperparameter
+# tuning, as it allows all runs to complete without stopping at the first
+# rebalancing failure. Let's instantiate our custom optimization with a 50% failure rate
+# and run a walk-forward analysis:
+model = CustomOptimization(failure_proba=0.5, raise_on_failure=False)
+pred = cross_val_predict(model, X, cv=walk_forward)
+
+
+# %%
+# `cross_val_predict` completed without interruption.
+# The resulting `MultiPeriodPortfolio` is composed of both `Portfolio` and
+# `FailedPortfolio` objects:
+print(pred.portfolios)
+
+# %%
+# Let's print the number of failed portfolios:
+print(pred.n_failed_portfolios)
+
+# %%
+# Even though `MultiPeriodPortfolio` contains failed portfolios, all statistics and
+# plots still work properly. This is because `FailedPortfolio` is designed to behave
+# like non-propagating NaNs:
+print(pred.summary())
+
+# %%
+# As shown below, `MultiPeriodPortfolio` plots gracefully handle `FailedPortfolio`
+# instances; for cumulative returns, these appear as gaps corresponding to failed
+# periods:
+fig = pred.plot_cumulative_returns()
+show(fig)

--- a/examples/mean_risk/plot_6_transaction_costs.py
+++ b/examples/mean_risk/plot_6_transaction_costs.py
@@ -169,21 +169,12 @@ for portfolio in pred1:
     pred2.append(new_portfolio)
 
 # %%
-# Finally, we train and test the model with TC. Note that we cannot use the
-# `cross_val_predict` function anymore because it uses parallelization and cannot handle
-# the `previous_weights` dependency between folds:
-pred3 = MultiPeriodPortfolio(name="pred3")
-
+# Finally, we train and test the model with TC.
+# `cross_val_predict` automatically handles the `previous_weights` dependency
+# between consecutive folds by propagating weights from one fold to the next.
 model.set_params(transaction_costs=transaction_costs)
-previous_weights = None
-for train, test in cv.split(X):
-    X_train = X.take(train)
-    X_test = X.take(test)
-    model.set_params(previous_weights=previous_weights)
-    model.fit(X_train)
-    portfolio = model.predict(X_test)
-    pred3.append(portfolio)
-    previous_weights = model.weights_
+pred3 = cross_val_predict(model, X, cv=cv)
+pred3.name = "pred3"
 
 # %%
 # We visualize the results by plotting the cumulative returns of the successive test

--- a/src/skfolio/__init__.py
+++ b/src/skfolio/__init__.py
@@ -12,7 +12,12 @@ from skfolio.measures import (
     RiskMeasure,
 )
 from skfolio.population import Population
-from skfolio.portfolio import BasePortfolio, MultiPeriodPortfolio, Portfolio
+from skfolio.portfolio import (
+    BasePortfolio,
+    FailedPortfolio,
+    MultiPeriodPortfolio,
+    Portfolio,
+)
 
 __version__ = importlib.metadata.version("skfolio")
 
@@ -20,6 +25,7 @@ __all__ = [
     "BaseMeasure",
     "BasePortfolio",
     "ExtraRiskMeasure",
+    "FailedPortfolio",
     "MultiPeriodPortfolio",
     "PerfMeasure",
     "Population",

--- a/src/skfolio/_constants.py
+++ b/src/skfolio/_constants.py
@@ -1,0 +1,25 @@
+"""Internal constants and enums used across skfolio."""
+
+# Copyright (c) 2025
+# Author: Hugo Delatte <hugo.delatte@skfoliolabs.com>
+# SPDX-License-Identifier: BSD-3-Clause
+
+from __future__ import annotations
+
+from enum import Enum
+
+
+class _ParamKey(str, Enum):
+    """Shared parameter keys used by estimators and portfolio.
+
+    These names are passed as keyword parameters between optimization
+    estimators and `Portfolio` classes to ensure consistent behavior.
+    """
+
+    TRANSACTION_COSTS = "transaction_costs"
+    MANAGEMENT_FEES = "management_fees"
+    PREVIOUS_WEIGHTS = "previous_weights"
+    RISK_FREE_RATE = "risk_free_rate"
+
+    def __str__(self) -> str:
+        return self.value

--- a/src/skfolio/measures/_measures.py
+++ b/src/skfolio/measures/_measures.py
@@ -6,6 +6,8 @@
 # Gini mean difference and OWA GMD weights features are derived
 # from Riskfolio-Lib, Copyright (c) 2020-2023, Dany Cajas, Licensed under BSD 3 clause.
 
+import warnings
+
 import numpy as np
 import numpy.typing as npt
 import scipy.optimize as sco
@@ -30,9 +32,18 @@ def mean(
         The computed mean.
         If `returns` is a 1D-array, the result is a float.
         If `returns` is a 2D-array, the result is a ndarray of shape (n_assets,).
+
+    Notes
+    -----
+    NaN handling:
+    - Unweighted: NaNs are ignored; all-NaN inputs yield NaN.
+    - Weighted: NaNs propagate.
     """
     if sample_weight is None:
-        return np.mean(returns, axis=0)
+        # Ignore NaNs and suppress warnings for all-NaN slices
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=RuntimeWarning)
+            return np.nanmean(returns, axis=0)
     return sample_weight @ returns
 
 
@@ -61,6 +72,12 @@ def mean_absolute_deviation(
         Mean absolute deviation.
         If `returns` is a 1D-array, the result is a float.
         If `returns` is a 2D-array, the result is a ndarray of shape (n_assets,).
+
+    Notes
+    -----
+    NaN handling:
+    - Unweighted: NaNs are ignored; all-NaN inputs yield NaN.
+    - Weighted: NaNs propagate.
     """
     if min_acceptable_return is None:
         min_acceptable_return = mean(returns, sample_weight=sample_weight)
@@ -98,6 +115,12 @@ def first_lower_partial_moment(
         First lower partial moment.
         If `returns` is a 1D-array, the result is a float.
         If `returns` is a 2D-array, the result is a ndarray of shape (n_assets,).
+
+    Notes
+    -----
+    NaN handling:
+    - Unweighted: NaNs are ignored; all-NaN inputs yield NaN.
+    - Weighted: NaNs propagate.
     """
     if min_acceptable_return is None:
         min_acceptable_return = mean(returns, sample_weight=sample_weight)
@@ -123,7 +146,7 @@ def variance(
          If False (default), computes the sample variance (unbiased); otherwise,
          computes the population variance (biased).
 
-     sample_weight : ndarray of shape (n_observations,), optional
+    sample_weight : ndarray of shape (n_observations,), optional
          Sample weights for each observation. If None, equal weights are assumed.
 
     Returns
@@ -132,9 +155,18 @@ def variance(
          Variance.
          If `returns` is a 1D-array, the result is a float.
          If `returns` is a 2D-array, the result is a ndarray of shape (n_assets,).
+
+    Notes
+    -----
+    NaN handling:
+    - Unweighted: NaNs are ignored; all-NaN inputs yield NaN.
+    - Weighted: NaNs propagate.
     """
     if sample_weight is None:
-        return np.var(returns, ddof=0 if biased else 1, axis=0)
+        # Ignore NaNs and suppress warnings for all-NaN slices
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=RuntimeWarning)
+            return np.nanvar(returns, ddof=0 if biased else 1, axis=0)
 
     biased_var = (
         sample_weight @ (returns - mean(returns, sample_weight=sample_weight)) ** 2
@@ -177,6 +209,12 @@ def semi_variance(
         Semi-variance.
         If `returns` is a 1D-array, the result is a float.
         If `returns` is a 2D-array, the result is a ndarray of shape (n_assets,).
+
+    Notes
+    -----
+    NaN handling:
+    - Unweighted: NaNs are ignored; all-NaN inputs yield NaN.
+    - Weighted: NaNs propagate.
     """
     if min_acceptable_return is None:
         min_acceptable_return = mean(returns, sample_weight=sample_weight)
@@ -220,6 +258,12 @@ def standard_deviation(
         Standard-deviation.
         If `returns` is a 1D-array, the result is a float.
         If `returns` is a 2D-array, the result is a ndarray of shape (n_assets,).
+
+    Notes
+    -----
+    NaN handling:
+    - Unweighted: NaNs are ignored; all-NaN inputs yield NaN.
+    - Weighted: NaNs propagate.
     """
     return np.sqrt(variance(returns, sample_weight=sample_weight, biased=biased))
 
@@ -254,6 +298,12 @@ def semi_deviation(
         Semi-deviation.
         If `returns` is a 1D-array, the result is a float.
         If `returns` is a 2D-array, the result is a ndarray of shape (n_assets,).
+
+    Notes
+    -----
+    NaN handling:
+    - Unweighted: NaNs are ignored; all-NaN inputs yield NaN.
+    - Weighted: NaNs propagate.
     """
     return np.sqrt(
         semi_variance(
@@ -284,6 +334,12 @@ def third_central_moment(
         Third central moment.
         If `returns` is a 1D-array, the result is a float.
         If `returns` is a 2D-array, the result is a ndarray of shape (n_assets,).
+
+    Notes
+    -----
+    NaN handling:
+    - Unweighted: NaNs are ignored; all-NaN inputs yield NaN.
+    - Weighted: NaNs propagate.
     """
     return mean(
         (returns - mean(returns, sample_weight=sample_weight)) ** 3,
@@ -314,6 +370,12 @@ def skew(
         Skew.
         If `returns` is a 1D-array, the result is a float.
         If `returns` is a 2D-array, the result is a ndarray of shape (n_assets,).
+
+    Notes
+    -----
+    NaN handling:
+    - Unweighted: NaNs are ignored; all-NaN inputs yield NaN.
+    - Weighted: NaNs propagate.
     """
     return (
         third_central_moment(returns, sample_weight)
@@ -340,6 +402,12 @@ def fourth_central_moment(
         Fourth central moment.
         If `returns` is a 1D-array, the result is a float.
         If `returns` is a 2D-array, the result is a ndarray of shape (n_assets,).
+
+    Notes
+    -----
+    NaN handling:
+    - Unweighted: NaNs are ignored; all-NaN inputs yield NaN.
+    - Weighted: NaNs propagate.
     """
     return mean(
         (returns - mean(returns, sample_weight=sample_weight)) ** 4,
@@ -369,6 +437,12 @@ def kurtosis(
         Kurtosis.
         If `returns` is a 1D-array, the result is a float.
         If `returns` is a 2D-array, the result is a ndarray of shape (n_assets,).
+
+    Notes
+    -----
+    NaN handling:
+    - Unweighted: NaNs are ignored; all-NaN inputs yield NaN.
+    - Weighted: NaNs propagate.
     """
     return (
         fourth_central_moment(returns, sample_weight=sample_weight)
@@ -402,6 +476,12 @@ def fourth_lower_partial_moment(
         Fourth lower partial moment.
         If `returns` is a 1D-array, the result is a float.
         If `returns` is a 2D-array, the result is a ndarray of shape (n_assets,).
+
+    Notes
+    -----
+    NaN handling:
+    - Unweighted: NaNs are ignored; all-NaN inputs yield NaN.
+    - Weighted: NaNs propagate.
     """
     if min_acceptable_return is None:
         min_acceptable_return = mean(returns)
@@ -422,8 +502,17 @@ def worst_realization(returns: npt.ArrayLike) -> float | np.ndarray:
         Worst realization.
         If `returns` is a 1D-array, the result is a float.
         If `returns` is a 2D-array, the result is a ndarray of shape (n_assets,).
+
+    Notes
+    -----
+    NaN handling:
+    - Unweighted: NaNs are ignored; all-NaN inputs yield NaN.
+    - Weighted: NaNs propagate.
     """
-    return -np.min(returns, axis=0)
+    with warnings.catch_warnings():
+        # all-NaN slice warning
+        warnings.simplefilter("ignore", category=RuntimeWarning)
+        return -np.nanmin(returns, axis=0)
 
 
 def value_at_risk(
@@ -449,22 +538,58 @@ def value_at_risk(
         Value at Risk.
         If `returns` is a 1D-array, the result is a float.
         If `returns` is a 2D-array, the result is a ndarray of shape (n_assets,).
-    """
-    returns = np.asarray(returns)
-    if sample_weight is None:
-        k = (1 - beta) * len(returns)
-        ik = max(0, int(np.ceil(k) - 1))
-        # We only need the first k elements so using `partition` O(n log(n)) is faster
-        # than `sort` O(n).
-        return -np.partition(returns, ik, axis=0)[ik]
 
+    Notes
+    -----
+    NaN handling:
+    - Unweighted: NaNs are ignored; all-NaN inputs yield NaN.
+    - Weighted: NaNs propagate.
+    """
+    returns = np.asarray(returns, dtype=float)
+
+    if np.isnan(returns).all():
+        return (
+            np.nan
+            if returns.ndim == 1
+            else np.full(returns.shape[1], np.nan, dtype=float)
+        )
+
+    def _func(arr: np.ndarray) -> float:
+        size = arr.shape[0]
+        if size == 0:
+            return np.nan
+        k = (1.0 - beta) * size
+        ik = max(0, int(np.ceil(k) - 1))
+        # We only need the first k elements, `partition` (~O(n) avg) beats
+        # `sort` (O(n log n))
+        part = np.partition(arr, ik, axis=0)
+        return -part[ik]
+
+    if sample_weight is None:
+        if not np.isnan(returns).any():
+            return _func(returns)
+
+        # Contains NaNs and returns is 1D
+        if returns.ndim == 1:
+            return _func(returns[~np.isnan(returns)])
+
+        # Contains NaNs and returns is 2D
+        n_assets = returns.shape[1]
+        return np.array(
+            [_func(returns[~np.isnan(returns[:, j]), j]) for j in range(n_assets)],
+            dtype=float,
+        )
+
+    # With sample weights
     sorted_idx = np.argsort(returns, axis=0)
     cum_weights = np.cumsum(sample_weight[sorted_idx], axis=0)
     i = np.apply_along_axis(
         np.searchsorted, axis=0, arr=cum_weights, v=1 - beta, side="left"
     )
+    # Returns is 1D
     if returns.ndim == 1:
         return -returns[sorted_idx][i]
+    # Returns is 2D
     return -np.diag(np.take_along_axis(returns, sorted_idx, axis=0)[i])
 
 
@@ -493,16 +618,49 @@ def cvar(
         CVaR.
         If `returns` is a 1D-array, the result is a float.
         If `returns` is a 2D-array, the result is a ndarray of shape (n_assets,).
-    """
-    returns = np.asarray(returns)
-    if sample_weight is None:
-        k = (1 - beta) * len(returns)
-        ik = max(0, int(np.ceil(k) - 1))
-        # We only need the first k elements so using `partition` O(n log(n)) is faster
-        # than `sort` O(n).
-        ret = np.partition(returns, ik, axis=0)
-        return -np.sum(ret[:ik], axis=0) / k + ret[ik] * (ik / k - 1)
 
+    Notes
+    -----
+    NaN handling:
+    - Unweighted: NaNs are ignored; all-NaN inputs yield NaN.
+    - Weighted: NaNs propagate.
+    """
+    returns = np.asarray(returns, dtype=float)
+
+    if np.isnan(returns).all():
+        return (
+            np.nan
+            if returns.ndim == 1
+            else np.full(returns.shape[1], np.nan, dtype=float)
+        )
+
+    def _func(arr: np.ndarray) -> float:
+        size = arr.shape[0]
+        if size == 0:
+            return np.nan
+        k = (1.0 - beta) * size
+        ik = max(0, int(np.ceil(k) - 1))
+        # We only need the first k elements, `partition` (~O(n) avg) beats
+        # `sort` (O(n log n))
+        part = np.partition(arr, ik, axis=0)
+        return -np.sum(part[:ik], axis=0) / k + part[ik] * (ik / k - 1.0)
+
+    if sample_weight is None:
+        if not np.isnan(returns).any():
+            return _func(returns)
+
+        # Contains NaNs and returns is 1D
+        if returns.ndim == 1:
+            return _func(returns[~np.isnan(returns)])
+
+        # Contains NaNs and returns is 2D
+        n_assets = returns.shape[1]
+        return np.array(
+            [_func(returns[~np.isnan(returns[:, j]), j]) for j in range(n_assets)],
+            dtype=float,
+        )
+
+    # With sample weight
     order = np.argsort(returns, axis=0)
     sorted_returns = np.take_along_axis(returns, order, axis=0)
     sorted_w = sample_weight[order]
@@ -519,12 +677,16 @@ def cvar(
             + _sorted_returns[_idx] * (1 - beta - _cum_w[_idx - 1])
         ) / (1 - beta)
 
+    # Returns is 1D
     if returns.ndim == 1:
         return -_func(idx, sorted_returns, sorted_w, cum_w)
+
+    # Returns is 2D
+    n_assets = returns.shape[1]
     return -np.array(
         [
             _func(idx[i], sorted_returns[:, i], sorted_w[:, i], cum_w[:, i])
-            for i in range(returns.shape[1])
+            for i in range(n_assets)
         ]
     )
 
@@ -561,6 +723,12 @@ def entropic_risk_measure(
         Entropic risk measure.
         If `returns` is a 1D-array, the result is a float.
         If `returns` is a 2D-array, the result is a ndarray of shape (n_assets,).
+
+    Notes
+    -----
+    NaN handling:
+    - Unweighted: NaNs are ignored; all-NaN inputs yield NaN.
+    - Weighted: NaNs propagate.
     """
     return theta * np.log(
         mean(np.exp(-returns / theta), sample_weight=sample_weight) / (1 - beta)
@@ -587,12 +755,14 @@ def evar(returns: npt.ArrayLike, beta: float = 0.95) -> float:
     value : float
         EVaR.
     """
+    if np.isnan(returns).all():
+        return np.nan
 
     def func(x: float) -> float:
         return entropic_risk_measure(returns=returns, theta=x, beta=beta)
 
     # The lower bound is chosen to avoid exp overflow
-    lower_bound = np.max(-returns) / 100
+    lower_bound = np.nanmax(-returns) / 100
     result = sco.minimize(
         func,
         x0=np.array([lower_bound * 2]),
@@ -627,11 +797,34 @@ def get_cumulative_returns(
     -------
     values: ndarray of shape (n_observations,) or (n_observations, n_assets)
         Cumulative returns.
+
+    Notes
+    -----
+    NaN handling:
+    Missing values (NaNs) remain at their original locations in the output and are
+    treated as neutral elements during accumulation, so they do not propagate to
+    subsequent values.
     """
-    if compounded:
-        cumulative_returns = base * np.cumprod(1 + returns, axis=0)
+    returns = np.asarray(returns, dtype=float)
+
+    if np.isnan(returns).all():
+        return np.full(returns.shape, np.nan, dtype=float)
+
+    if np.isnan(returns).any():
+        mask = np.isnan(returns)
+        returns_clean = np.nan_to_num(returns, nan=0.0)
     else:
-        cumulative_returns = np.cumsum(returns, axis=0)
+        mask = None
+        returns_clean = returns
+
+    if compounded:
+        cumulative_returns = base * np.cumprod(1 + returns_clean, axis=0)
+    else:
+        cumulative_returns = np.cumsum(returns_clean, axis=0)
+
+    if mask is not None:
+        cumulative_returns[mask] = np.nan
+
     return cumulative_returns
 
 
@@ -651,12 +844,34 @@ def get_drawdowns(returns: npt.ArrayLike, compounded: bool = False) -> np.ndarra
     -------
     values: ndarray of shape (n_observations,) or (n_observations, n_assets)
        Drawdowns.
+
+    Notes
+    -----
+    NaN handling:
+    Missing values (NaNs) remain at their original locations in the output and are
+    treated as neutral elements during accumulation, so they do not propagate to
+    subsequent values.
     """
+    if np.isnan(returns).all():
+        return np.full(returns.shape, np.nan, dtype=float)
+
     cumulative_returns = get_cumulative_returns(returns=returns, compounded=compounded)
-    if compounded:
-        drawdowns = cumulative_returns / np.maximum.accumulate(cumulative_returns) - 1
+
+    if np.isnan(cumulative_returns).any():
+        mask = np.isnan(cumulative_returns)
+        cum_clean = np.nan_to_num(cumulative_returns, nan=-np.inf)
     else:
-        drawdowns = cumulative_returns - np.maximum.accumulate(cumulative_returns)
+        mask = None
+        cum_clean = cumulative_returns
+
+    if compounded:
+        drawdowns = cum_clean / np.maximum.accumulate(cum_clean, axis=0) - 1
+    else:
+        drawdowns = cum_clean - np.maximum.accumulate(cum_clean, axis=0)
+
+    if mask is not None:
+        drawdowns[mask] = np.nan
+
     return drawdowns
 
 
@@ -821,8 +1036,33 @@ def gini_mean_difference(returns: npt.ArrayLike) -> float | np.ndarray:
         If `returns` is a 1D-array, the result is a float.
         If `returns` is a 2D-array, the result is a ndarray of shape (n_assets,).
     """
-    w = owa_gmd_weights(len(returns))
-    return w @ np.sort(returns, axis=0)
+    returns = np.asarray(returns, dtype=float)
+
+    # No NaNs
+    if not np.isnan(returns).any():
+        w = owa_gmd_weights(returns.shape[0])
+        return w @ np.sort(returns, axis=0)
+
+    # 1D with NaN
+    if returns.ndim == 1:
+        v = returns[~np.isnan(returns)]
+        if v.size == 0:
+            return np.nan
+        w = owa_gmd_weights(v.size)
+        return w @ np.sort(v)
+
+    # 2D with NaNs
+    n_assets = returns.shape[1]
+    out = np.full(n_assets, np.nan, dtype=float)
+    isnan = np.isnan(returns)
+    for j in range(n_assets):
+        col = returns[:, j]
+        v = col[~isnan[:, j]]
+        if v.size == 0:
+            continue  # leave NaN
+        w = owa_gmd_weights(v.size)
+        out[j] = w @ np.sort(v)
+    return out
 
 
 def effective_number_assets(weights: np.ndarray) -> float:

--- a/src/skfolio/optimization/_base.py
+++ b/src/skfolio/optimization/_base.py
@@ -1,22 +1,10 @@
-"""Base Optimization estimator."""
+"""Base classes and utilities for portfolio optimization estimators.
 
-# Author: Hugo Delatte <delatte.hugo@gmail.com>
-# SPDX-License-Identifier: BSD-3-Clause
+This module defines the abstract `BaseOptimization` estimator that all
+optimization algorithms in skfolio should inherit from.
+"""
 
-from abc import ABC, abstractmethod
-
-import numpy as np
-import numpy.typing as npt
-import pandas as pd
-import sklearn.base as skb
-from sklearn.utils.validation import check_is_fitted
-
-from skfolio.measures import RatioMeasure
-from skfolio.population import Population
-from skfolio.portfolio import Portfolio
-from skfolio.prior import ReturnDistribution
-
-# Copyright (c) 2023
+# Copyright (c) 2023-2025
 # Author: Hugo Delatte <delatte.hugo@gmail.com>
 # SPDX-License-Identifier: BSD-3-Clause
 # Implementation derived from:
@@ -24,61 +12,298 @@ from skfolio.prior import ReturnDistribution
 # scikit-learn, Copyright (c) 2007-2010 David Cournapeau, Fabian Pedregosa, Olivier
 # Grisel Licensed under BSD 3 clause.
 
+from __future__ import annotations
+
+import warnings
+from abc import ABC, abstractmethod
+from collections.abc import Mapping
+from functools import wraps
+from typing import Any, Literal
+
+import numpy as np
+import numpy.typing as npt
+import pandas as pd
+import sklearn as sk
+import sklearn.base as skb
+from sklearn.utils.validation import check_is_fitted
+
+import skfolio.typing as skt
+from skfolio._constants import _ParamKey
+from skfolio.measures import RatioMeasure
+from skfolio.population import Population
+from skfolio.portfolio import FailedPortfolio, Portfolio
+from skfolio.prior import ReturnDistribution
+from skfolio.utils.tools import input_to_array
+
 
 class BaseOptimization(skb.BaseEstimator, ABC):
     """Base class for all portfolio optimizations in skfolio.
 
-    portfolio_params :  dict, optional
-        Portfolio parameters passed to the portfolio evaluated by the `predict` and
-        `score` methods. If not provided, the `name`, `transaction_costs`,
-        `management_fees`, `previous_weights` and `risk_free_rate` are copied from the
-        optimization model and passed to the portfolio.
+    Parameters
+    ----------
+    portfolio_params : dict, optional
+        Portfolio parameters forwarded to the resulting `Portfolio` in `predict`.
+        If not provided and if available on the estimator, the following
+        attributes are propagated to the portfolio by default: `name`,
+        `transaction_costs`, `management_fees`, `previous_weights` and `risk_free_rate`.
+
+    fallback : BaseOptimization | list[BaseOptimization] | "previous_weights", optional
+        Fallback estimator or a list of estimators to try, in order, when the primary
+        optimization raises during `fit`. When a fallback succeeds, its fitted
+        `weights_` are copied back to the primary estimator so that `fit` still returns
+        the original instance. For traceability, `fallback_` stores the successful
+        estimator (or the string `"previous_weights"`), and `fallback_chain_` stores
+        each attempt with the associated outcome.
+
+    previous_weights : float | dict[str, float] | array-like of shape (n_assets,), optional
+        Previous asset weights. Some estimators use this to compute costs or turnover.
+        Additionally, when `fallback="previous_weights"`, failures will fall back to
+        these weights if provided.
+
+    raise_on_failure : bool, default=True
+        Controls error handling when fitting fails.
+        - If True: failures during `fit` are raised and no `weights_` are set.
+          Subsequent calls to `predict` will raise a not-fitted error.
+        - If False: errors are not raised; a warning is emitted and `weights_` is set to
+          `None`. Subsequent calls to `predict` will return a `FailedPortfolio`.
+        When fallbacks are specified, this behavior applies only after all fallbacks are
+        exhausted.
 
     Attributes
     ----------
     weights_ : ndarray of shape (n_assets,) or (n_optimizations, n_assets)
         Weights of the assets.
 
+    n_features_in_ : int
+        Number of assets seen during `fit`.
+
+    feature_names_in_ : ndarray of shape (`n_features_in_`,)
+        Names of assets seen during `fit`. Defined only when `X`
+        has assets names that are all strings.
+
+    fallback_ : BaseOptimization | "previous_weights" | None
+        The fallback estimator instance, or the string `"previous_weights"`, that
+        produced the final result. `None` if no fallback was used.
+
+    fallback_chain_ : list[tuple[str, str]] | None
+        Sequence describing the optimization fallback attempts. Each element is a
+        pair `(estimator_repr, outcome)` where `estimator_repr` is the string
+        representation of the primary estimator or a fallback (e.g. `"EqualWeighted()"`,
+        `"previous_weights"`), and `outcome` is `"success"` if that step produced
+        a valid solution, otherwise the stringified error message. For successful
+        fits without any fallback, this is `None`.
+
+    error_ : str | list[str] | None
+        Captured error message(s) when `fit` fails. For multi-portfolio outputs
+        (`weights_` is 2D), this is a list aligned with portfolios.
+
     Notes
     -----
-    All estimators should specify all the parameters that can be set
-    at the class level in their `__init__` as explicit keyword
-    arguments (no `*args` or `**kwargs`).
+    All estimators should specify all parameters as explicit keyword arguments in
+    `__init__` (no `*args` or `**kwargs`), following scikit-learn conventions.
     """
 
     weights_: np.ndarray
     n_features_in_: int
     feature_names_in_: np.ndarray
+    fallback_: BaseOptimization | Literal["previous_weights"] | None
+    fallback_chain_: list[tuple[str, str]] | None
+    error_: str | list[str] | None
 
     @abstractmethod
-    def __init__(self, portfolio_params: dict | None = None):
+    def __init__(
+        self,
+        portfolio_params: dict | None = None,
+        fallback: skt.Fallback = None,
+        previous_weights: skt.MultiInput | None = None,
+        raise_on_failure: bool = True,
+    ):
         self.portfolio_params = portfolio_params
+        self.fallback = fallback
+        self.previous_weights = previous_weights
+        self.raise_on_failure = raise_on_failure
+
+    # Automatically wrap all subclasses' fit to add fallback behavior
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+
+        original_fit = cls.__dict__.get("fit")
+        if original_fit is None or getattr(original_fit, "_fallback_wrapped", False):
+            return
+
+        @wraps(original_fit)
+        def _wrapped_fit(
+            self, X: npt.ArrayLike, y: npt.ArrayLike | None = None, **fit_params
+        ):
+            self.fallback_ = None
+            self.fallback_chain_ = None
+            self.error_ = None
+
+            try:
+                original_fit(self, X, y, **fit_params)
+            except Exception as primary_error:
+                try:
+                    self._run_fallback_chain(
+                        X=X, y=y, primary_error=primary_error, **fit_params
+                    )
+                except Exception as last_error:
+                    self.error_ = str(last_error)
+                    if self.raise_on_failure:
+                        raise
+                    warnings.warn(
+                        (
+                            f"{self.__class__.__name__}.fit failed: {last_error}. "
+                            "Because raise_on_failure=False, weights_ is set to None. "
+                            "Inspect 'error_' and 'fallback_chain_' for details."
+                        ),
+                        stacklevel=2,
+                    )
+                    self.weights_ = None
+            return self
+
+        _wrapped_fit._fallback_wrapped = True
+        cls.fit = _wrapped_fit
+
+    def _run_fallback_chain(
+        self,
+        X: npt.ArrayLike,
+        y: npt.ArrayLike | None,
+        primary_error: Exception,
+        **fit_params,
+    ) -> None:
+        """Execute the configured fallback chain after a primary `fit` failure.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_observations, n_assets)
+            Training data passed to `fit`.
+
+        y : array-like or None
+            Optional target data.
+
+        primary_error : Exception
+            The exception raised by the primary estimator.
+
+        **fit_params : dict
+            Additional keyword arguments forwarded to each fallback's `fit`.
+
+        Raises
+        ------
+        Exception
+            Re-raises the last encountered error if all fallbacks fail.
+        """
+        fallback = self.fallback
+
+        if fallback is None:
+            raise primary_error
+
+        # Log the primary error in fallback_chain_ only when fallbacks are provided
+        self.fallback_chain_ = [(str(self), str(primary_error))]
+
+        n_assets = X.shape[1]
+
+        if not isinstance(fallback, list | tuple):
+            fallback = [fallback]
+
+        if len(fallback) == 0:
+            raise primary_error
+
+        last_error: Exception = primary_error
+        for fb in fallback:
+            try:
+                fb = _validate_fallback(fb)
+                if fb == _ParamKey.PREVIOUS_WEIGHTS.value:
+                    self._fallback_to_previous_weights_or_raise(n_assets=n_assets)
+                    return
+
+                fb_est = sk.clone(fb)
+
+                # previous_weights are propagated to the fallbacks
+                if self.previous_weights is not None:
+                    if fb_est.previous_weights is not None:
+                        warnings.warn(
+                            (
+                                "previous_weights are automatically propagated to "
+                                "fallback estimators. To silence this warning, leave "
+                                "the fallback's previous_weights as None."
+                            ),
+                            stacklevel=2,
+                        )
+                    fb_est.set_params(previous_weights=self.previous_weights)
+
+                fb_est.fit(X, y, **fit_params)
+
+                # Success: copy learned artifacts back to self
+                for name in ("weights_", "n_features_in_", "feature_names_in_"):
+                    setattr(self, name, getattr(fb_est, name))
+
+                self.fallback_ = fb_est
+                self.fallback_chain_.append((str(fb_est), "success"))
+                return
+            except Exception as err:  # try next fallback
+                last_error = err
+                self.fallback_chain_.append((str(fb), str(err)))
+                continue
+
+        # All fallbacks failed
+        if last_error is not None:
+            # Defer raising to the caller which decides based on raise_on_failure
+            raise last_error
+        raise RuntimeError(
+            "All fallback estimators failed; inspect 'fallback_chain_' for details."
+        )
+
+    def _fallback_to_previous_weights_or_raise(self, n_assets: int) -> None:
+        """Fallback to `previous_weights` or raise if unavailable/invalid.
+
+        Parameters
+        ----------
+        n_assets : int
+            Number of assets used to validate the shape of `previous_weights`.
+
+        Raises
+        ------
+        RuntimeError
+            If `previous_weights` is `None` when the fallback is requested.
+        """
+        try:
+            if self.previous_weights is None:
+                raise RuntimeError(
+                    "Fallback 'previous_weights' requested, but 'previous_weights' is None. "
+                    "Provide valid previous weights or remove this fallback."
+                )
+            self.weights_ = self._clean_previous_weights(n_assets=n_assets)
+            self.fallback_ = _ParamKey.PREVIOUS_WEIGHTS.value
+            self.fallback_chain_.append((_ParamKey.PREVIOUS_WEIGHTS.value, "success"))
+
+        except Exception as error:
+            self.fallback_chain_.append((_ParamKey.PREVIOUS_WEIGHTS.value, str(error)))
+            raise
 
     @abstractmethod
     def fit(self, X: npt.ArrayLike, y: npt.ArrayLike | None = None):
         pass
 
     def predict(self, X: npt.ArrayLike | ReturnDistribution) -> Portfolio | Population:
-        """Predict the `Portfolio` or `Population` of `Portfolio` on `X` based on the
-        fitted weights.
+        """Predict the `Portfolio` or a `Population` of portfolios on `X`.
 
         Optimization estimators can return a 1D or a 2D array of `weights`.
-        For a 1D array, the prediction returns a `Portfolio`.
-        For a 2D array, the prediction returns a `Population` of `Portfolio`.
+        For a 1D array, the prediction is a single `Portfolio`.
+        For a 2D array, the prediction is a `Population` of `Portfolio`.
 
-        If `name` is not provided in the portfolio arguments, we use the first
-        500 characters of the estimator name.
+        If `name` is not provided in the portfolio parameters, the estimator
+        class name is used.
 
         Parameters
         ----------
-        X : array-like of shape (n_observations, n_assets)
-            Price returns of the assets.
+        X : array-like of shape (n_observations, n_assets) | ReturnDistribution
+            Asset returns or a `ReturnDistribution` carrying returns and optional
+            sample weights.
 
         Returns
         -------
-        prediction : Portfolio | Population
-            `Portfolio` or `Population` of `Portfolio` estimated on `X` based on the
-            fitted `weights`.
+        Portfolio | Population
+            The predicted `Portfolio` or `Population` based on the fitted `weights`.
         """
         check_is_fitted(self, "weights_")
 
@@ -101,10 +326,10 @@ class BaseOptimization(skb.BaseEstimator, ABC):
 
         # Set the default portfolio parameters equal to the optimization parameters
         for param in [
-            "transaction_costs",
-            "management_fees",
-            "previous_weights",
-            "risk_free_rate",
+            _ParamKey.TRANSACTION_COSTS.value,
+            _ParamKey.MANAGEMENT_FEES.value,
+            _ParamKey.PREVIOUS_WEIGHTS.value,
+            _ParamKey.RISK_FREE_RATE.value,
         ]:
             if param not in ptf_kwargs and hasattr(self, param):
                 ptf_kwargs[param] = getattr(self, param)
@@ -113,30 +338,47 @@ class BaseOptimization(skb.BaseEstimator, ABC):
         # 500 characters of the optimization estimator's name
         name = ptf_kwargs.pop("name", type(self).__name__)
 
+        # Add fallback chain
+        ptf_kwargs["fallback_chain"] = self.fallback_chain_
+
+        # If weights are None and raise_on_failure is False, we return a FailedPortfolio
+        if self.weights_ is None:
+            return FailedPortfolio(
+                name=name, optimization_error=self.error_, **ptf_kwargs
+            )
+
         # Optimization estimators can return a 1D or a 2D array of weights.
         # For a 1D array we return a portfolio.
+        if self.weights_.ndim == 1:
+            return Portfolio(weights=self.weights_, name=name, **ptf_kwargs)
+
         # For a 2D array we return a population of portfolios.
-        if self.weights_.ndim == 2:
-            n_portfolios = self.weights_.shape[0]
-            return Population(
-                [
-                    Portfolio(
-                        weights=self.weights_[i],
-                        name=f"ptf{i} - {name}",
+        n_portfolios = self.weights_.shape[0]
+        population = Population([])
+        for i in range(n_portfolios):
+            ptf_name = f"ptf{i} - {name}"
+            if np.isnan(self.weights_[i]).all():
+                error = self.error_[i] if isinstance(self.error_, list) else None
+                population.append(
+                    FailedPortfolio(
+                        name=ptf_name,
+                        optimization_error=error,
                         **ptf_kwargs,
                     )
-                    for i in range(n_portfolios)
-                ]
-            )
-        return Portfolio(weights=self.weights_, name=name, **ptf_kwargs)
+                )
+            else:
+                population.append(
+                    Portfolio(weights=self.weights_[i], name=ptf_name, **ptf_kwargs)
+                )
+        return population
 
     def score(
         self, X: npt.ArrayLike | ReturnDistribution, y: npt.ArrayLike = None
     ) -> float:
-        """Prediction score.
-        If the prediction is a single `Portfolio`, the score is the Sharpe Ratio.
-        If the prediction is a `Population` of `Portfolio`, the score is the mean of all
-        the portfolios Sharpe Ratios in the population.
+        """Prediction score using the Sharpe Ratio.
+        If the prediction is a single `Portfolio`, the score is its Sharpe Ratio.
+        If the prediction is a `Population`, the score is the mean Sharpe Ratio
+        across portfolios.
 
         Parameters
         ----------
@@ -163,6 +405,9 @@ class BaseOptimization(skb.BaseEstimator, ABC):
         `Population` of `Portfolio` on `X` based on the fitted `weights`.
         For factor models, use `fit(X, y)` then `predict(X)` separately.
 
+        If fitting fails and `raise_on_failure=False`, this returns a
+        `FailedPortfolio`.
+
         Parameters
         ----------
         X : array-like of shape (n_observations, n_assets)
@@ -170,8 +415,167 @@ class BaseOptimization(skb.BaseEstimator, ABC):
 
         Returns
         -------
-        prediction : Portfolio | Population
-            `Portfolio` or `Population` of `Portfolio` estimated on `X` based on the
-            fitted `weights`.
+        Portfolio | Population
+            The predicted `Portfolio` or `Population` based on the fitted `weights`.
         """
         return self.fit(X).predict(X)
+
+    @property
+    def needs_previous_weights(self) -> bool:
+        """Whether `previous_weights` must be propagated between folds/rebalances.
+
+        Used by `cross_val_predict` to decide whether to run sequentially and pass
+        the weights from the previous rebalancing to the next. This is `True` when
+        transaction costs, a maximum turnover, or a fallback depending on
+        `previous_weights` are present.
+        """
+        if _has_transaction_cost(
+            getattr(self, _ParamKey.TRANSACTION_COSTS.value, None)
+        ):
+            return True
+
+        if getattr(self, "max_turnover", None) is not None:
+            return True
+
+        fallback = self.fallback
+        if fallback is not None:
+            if not isinstance(fallback, list | tuple):
+                fallback = [fallback]
+
+            for fb in fallback:
+                fb = _validate_fallback(fb)
+                if fb == _ParamKey.PREVIOUS_WEIGHTS.value or fb.needs_previous_weights:
+                    return True
+
+        return False
+
+    def _clean_input(
+        self,
+        value: float | dict | npt.ArrayLike | None,
+        n_assets: int,
+        fill_value: Any,
+        name: str,
+    ) -> float | np.ndarray:
+        """Convert input to a cleaned float or 1D ndarray.
+
+        Parameters
+        ----------
+        value : float | dict | array-like | None
+            Input value to clean.
+
+        n_assets : int
+            Number of assets. Used to verify the shape of the converted array.
+
+        fill_value : Any
+            When `value` is a dictionary, keys not present in the asset names are
+            filled with `fill_value` in the converted array.
+
+        name : str
+            Name used for error messages.
+
+        Returns
+        -------
+        float | ndarray of shape (n_assets,)
+            The cleaned scalar or 1D array.
+        """
+        if value is None:
+            return fill_value
+        if np.isscalar(value):
+            return float(value)
+        return input_to_array(
+            items=value,
+            n_assets=n_assets,
+            fill_value=fill_value,
+            dim=1,
+            assets_names=(
+                self.feature_names_in_ if hasattr(self, "feature_names_in_") else None
+            ),
+            name=name,
+        )
+
+    def _clean_previous_weights(self, n_assets: int) -> np.ndarray:
+        """Return validated previous weights as a 1D array of length `n_assets`.
+
+        Converts `previous_weights` to a numpy array using `_clean_input`, accepting
+        scalars, mappings keyed by asset name, or array-like inputs. Scalars are
+        broadcast to all assets. Missing assets in mappings are filled with zeros.
+
+        Parameters
+        ----------
+        n_assets : int
+            Number of assets; used to validate shape and for broadcasting.
+
+        Returns
+        -------
+        ndarray of shape (n_assets,)
+            Cleaned previous weights.
+        """
+        previous_weights = self._clean_input(
+            self.previous_weights,
+            n_assets=n_assets,
+            fill_value=0,
+            name=_ParamKey.PREVIOUS_WEIGHTS.value,
+        )
+        if np.isscalar(previous_weights):
+            previous_weights = np.full(n_assets, float(previous_weights))
+        return previous_weights
+
+
+def _has_transaction_cost(x: Any) -> bool:
+    """Return True if any non-zero transaction cost is present in `x`.
+
+    Accepts scalars, arrays, nested mappings, or structures convertible to arrays.
+    Zero or empty values are treated as no cost.
+    """
+    if x is None:
+        return False
+
+    if isinstance(x, Mapping):
+        # Empty dict -> no costs; otherwise recurse
+        return any(_has_transaction_cost(v) for v in x.values())
+
+    try:
+        arr = np.asarray(x, dtype=float)
+    except Exception:
+        # If coercion fails, assume non-zero to be conservative
+        return True
+
+    if arr.size == 0:
+        return False
+
+    return not np.allclose(arr, 0.0, atol=1e-15, rtol=1e-18, equal_nan=False)
+
+
+def _validate_fallback(
+    fallback: Literal["previous_weights"] | BaseOptimization,
+) -> Literal["previous_weights"] | BaseOptimization:
+    """Validate the fallback specification.
+
+    Parameters
+    ----------
+    fallback : BaseOptimization | "previous_weights"
+        The configured fallback.
+
+    Returns
+    -------
+    BaseOptimization | "previous_weights"
+        The validated fallback, unchanged.
+
+    Raises
+    ------
+    ValueError
+        If `fallback` is a string different from `"previous_weights"`.
+    TypeError
+        If `fallback` is not a string and not an instance of `BaseOptimization`.
+    """
+    if isinstance(fallback, str):
+        if fallback != _ParamKey.PREVIOUS_WEIGHTS.value:
+            raise ValueError(
+                f"Unsupported string fallback: {fallback!r}. Only 'previous_weights' is allowed."
+            )
+        return _ParamKey.PREVIOUS_WEIGHTS.value
+    if not isinstance(fallback, BaseOptimization):
+        raise TypeError(
+            f"Fallback estimators must inherit from BaseOptimization (got {type(fallback).__name__})."
+        )
+    return fallback

--- a/src/skfolio/optimization/_base.py
+++ b/src/skfolio/optimization/_base.py
@@ -47,13 +47,14 @@ class BaseOptimization(skb.BaseEstimator, ABC):
         attributes are propagated to the portfolio by default: `name`,
         `transaction_costs`, `management_fees`, `previous_weights` and `risk_free_rate`.
 
-    fallback : BaseOptimization | list[BaseOptimization] | "previous_weights", optional
+    fallback : BaseOptimization | "previous_weights" | list[BaseOptimization | "previous_weights"], optional
         Fallback estimator or a list of estimators to try, in order, when the primary
-        optimization raises during `fit`. When a fallback succeeds, its fitted
-        `weights_` are copied back to the primary estimator so that `fit` still returns
-        the original instance. For traceability, `fallback_` stores the successful
-        estimator (or the string `"previous_weights"`), and `fallback_chain_` stores
-        each attempt with the associated outcome.
+        optimization raises during `fit`. Alternatively, use `"previous_weights"` 
+        (alone or in a list) to fall back to the estimator's `previous_weights`.
+        When a fallback succeeds, its fitted `weights_` are copied back to the primary 
+        estimator so that `fit` still returns the original instance. For traceability, 
+        `fallback_` stores the successful estimator (or the string `"previous_weights"`)
+         and `fallback_chain_` stores each attempt with the associated outcome.
 
     previous_weights : float | dict[str, float] | array-like of shape (n_assets,), optional
         Previous asset weights. Some estimators use this to compute costs or turnover.
@@ -62,12 +63,12 @@ class BaseOptimization(skb.BaseEstimator, ABC):
 
     raise_on_failure : bool, default=True
         Controls error handling when fitting fails.
-        - If True: failures during `fit` are raised and no `weights_` are set.
-          Subsequent calls to `predict` will raise a not-fitted error.
-        - If False: errors are not raised; a warning is emitted and `weights_` is set to
-          `None`. Subsequent calls to `predict` will return a `FailedPortfolio`.
-        When fallbacks are specified, this behavior applies only after all fallbacks are
-        exhausted.
+        If True, any failure during `fit` is raised immediately, no `weights_` are
+        set and subsequent calls to `predict` will raise a `NotFittedError`.
+        If False, errors are not raised; instead, a warning is emitted, `weights_`
+        is set to `None` and subsequent calls to `predict` will return a
+        `FailedPortfolio`. When fallbacks are specified, this behavior applies only
+        after all fallbacks have been exhausted.
 
     Attributes
     ----------

--- a/src/skfolio/optimization/cluster/_nco.py
+++ b/src/skfolio/optimization/cluster/_nco.py
@@ -128,27 +128,27 @@ class NestedClustersOptimization(BaseOptimization):
         attributes are propagated to the portfolio by default: `name` and
         `previous_weights`.
 
-    fallback : BaseOptimization | list[BaseOptimization] | "previous_weights", optional
+    fallback : BaseOptimization | "previous_weights" | list[BaseOptimization | "previous_weights"], optional
         Fallback estimator or a list of estimators to try, in order, when the primary
-        optimization raises during `fit`. When a fallback succeeds, its fitted
-        `weights_` are copied back to the primary estimator so that `fit` still returns
-        the original instance. For traceability, `fallback_` stores the successful
-        estimator (or the string `"previous_weights"`), and `fallback_chain_` stores
-        each attempt with the associated outcome.
+        optimization raises during `fit`. Alternatively, use `"previous_weights"` 
+        (alone or in a list) to fall back to the estimator's `previous_weights`.
+        When a fallback succeeds, its fitted `weights_` are copied back to the primary 
+        estimator so that `fit` still returns the original instance. For traceability, 
+        `fallback_` stores the successful estimator (or the string `"previous_weights"`)
+         and `fallback_chain_` stores each attempt with the associated outcome.
 
     previous_weights : float | dict[str, float] | array-like of shape (n_assets,), optional
-        Previous asset weights. Some estimators use this to compute costs or turnover.
-        Additionally, when `fallback="previous_weights"`, failures will fall back to
-        these weights if provided.
+        When `fallback="previous_weights"`, failures will fall back to these weights
+        if provided.
 
     raise_on_failure : bool, default=True
         Controls error handling when fitting fails.
-        - If True: failures during `fit` are raised and no `weights_` are set.
-          Subsequent calls to `predict` will raise a not-fitted error.
-        - If False: errors are not raised; a warning is emitted and `weights_` is set to
-          `None`. Subsequent calls to `predict` will return a `FailedPortfolio`.
-        When fallbacks are specified, this behavior applies only after all fallbacks are
-        exhausted.
+        If True, any failure during `fit` is raised immediately, no `weights_` are
+        set and subsequent calls to `predict` will raise a `NotFittedError`.
+        If False, errors are not raised; instead, a warning is emitted, `weights_`
+        is set to `None` and subsequent calls to `predict` will return a
+        `FailedPortfolio`. When fallbacks are specified, this behavior applies only
+        after all fallbacks have been exhausted.
 
     Attributes
     ----------

--- a/src/skfolio/optimization/cluster/hierarchical/_base.py
+++ b/src/skfolio/optimization/cluster/hierarchical/_base.py
@@ -189,22 +189,23 @@ class BaseHierarchicalOptimization(BaseOptimization, ABC):
         attributes are propagated to the portfolio by default: `name`,
         `transaction_costs`, `management_fees`, `previous_weights` and `risk_free_rate`.
 
-    fallback : BaseOptimization | list[BaseOptimization] | "previous_weights", optional
+    fallback : BaseOptimization | "previous_weights" | list[BaseOptimization | "previous_weights"], optional
         Fallback estimator or a list of estimators to try, in order, when the primary
-        optimization raises during `fit`. When a fallback succeeds, its fitted
-        `weights_` are copied back to the primary estimator so that `fit` still returns
-        the original instance. For traceability, `fallback_` stores the successful
-        estimator (or the string `"previous_weights"`), and `fallback_chain_` stores
-        each attempt with the associated outcome.
+        optimization raises during `fit`. Alternatively, use `"previous_weights"` 
+        (alone or in a list) to fall back to the estimator's `previous_weights`.
+        When a fallback succeeds, its fitted `weights_` are copied back to the primary 
+        estimator so that `fit` still returns the original instance. For traceability, 
+        `fallback_` stores the successful estimator (or the string `"previous_weights"`)
+         and `fallback_chain_` stores each attempt with the associated outcome.
 
     raise_on_failure : bool, default=True
         Controls error handling when fitting fails.
-        - If True: failures during `fit` are raised and no `weights_` are set.
-          Subsequent calls to `predict` will raise a not-fitted error.
-        - If False: errors are not raised; a warning is emitted and `weights_` is set to
-          `None`. Subsequent calls to `predict` will return a `FailedPortfolio`.
-        When fallbacks are specified, this behavior applies only after all fallbacks are
-        exhausted.
+        If True, any failure during `fit` is raised immediately, no `weights_` are
+        set and subsequent calls to `predict` will raise a `NotFittedError`.
+        If False, errors are not raised; instead, a warning is emitted, `weights_`
+        is set to `None` and subsequent calls to `predict` will return a
+        `FailedPortfolio`. When fallbacks are specified, this behavior applies only
+        after all fallbacks have been exhausted.
 
     Attributes
     ----------

--- a/src/skfolio/optimization/cluster/hierarchical/_base.py
+++ b/src/skfolio/optimization/cluster/hierarchical/_base.py
@@ -7,6 +7,8 @@
 # Riskfolio-Lib, Copyright (c) 2020-2023, Dany Cajas, Licensed under BSD 3 clause.
 # scikit-learn, Copyright (c) 2007-2010 David Cournapeau, Fabian Pedregosa, Olivier
 
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from typing import Any
 
@@ -178,12 +180,31 @@ class BaseHierarchicalOptimization(BaseOptimization, ABC):
         (asset name/asset previous weight) and the input `X` of the `fit` method must
         be a DataFrame with the asset names in columns.
         The default (`None`) means no previous weights.
+        Additionally, when `fallback="previous_weights"`, failures will fall back to
+        these weights if provided.
 
-    portfolio_params :  dict, optional
-        Portfolio parameters passed to the portfolio evaluated by the `predict` and
-        `score` methods. If not provided, the `name`, `transaction_costs`,
-        `management_fees`, `previous_weights` and `risk_free_rate` are copied from the
-        optimization model and passed to the portfolio.
+    portfolio_params : dict, optional
+        Portfolio parameters forwarded to the resulting `Portfolio` in `predict`.
+        If not provided and if available on the estimator, the following
+        attributes are propagated to the portfolio by default: `name`,
+        `transaction_costs`, `management_fees`, `previous_weights` and `risk_free_rate`.
+
+    fallback : BaseOptimization | list[BaseOptimization] | "previous_weights", optional
+        Fallback estimator or a list of estimators to try, in order, when the primary
+        optimization raises during `fit`. When a fallback succeeds, its fitted
+        `weights_` are copied back to the primary estimator so that `fit` still returns
+        the original instance. For traceability, `fallback_` stores the successful
+        estimator (or the string `"previous_weights"`), and `fallback_chain_` stores
+        each attempt with the associated outcome.
+
+    raise_on_failure : bool, default=True
+        Controls error handling when fitting fails.
+        - If True: failures during `fit` are raised and no `weights_` are set.
+          Subsequent calls to `predict` will raise a not-fitted error.
+        - If False: errors are not raised; a warning is emitted and `weights_` is set to
+          `None`. Subsequent calls to `predict` will return a `FailedPortfolio`.
+        When fallbacks are specified, this behavior applies only after all fallbacks are
+        exhausted.
 
     Attributes
     ----------
@@ -205,13 +226,32 @@ class BaseHierarchicalOptimization(BaseOptimization, ABC):
     feature_names_in_ : ndarray of shape (`n_features_in_`,)
        Names of features seen during `fit`. Defined only when `X`
        has feature names that are all strings.
+
+    fallback_ : BaseOptimization | "previous_weights" | None
+        The fallback estimator instance, or the string `"previous_weights"`, that
+        produced the final result. `None` if no fallback was used.
+
+    fallback_chain_ : list[tuple[str, str]] | None
+        Sequence describing the optimization fallback attempts. Each element is a
+        pair `(estimator_repr, outcome)` where `estimator_repr` is the string
+        representation of the primary estimator or a fallback (e.g. `"EqualWeighted()"`,
+        `"previous_weights"`), and `outcome` is `"success"` if that step produced
+        a valid solution, otherwise the stringified error message. For successful
+        fits without any fallback, this is `None`.
+
+    error_ : str | list[str] | None
+        Captured error message(s) when `fit` fails. For multi-portfolio outputs
+        (`weights_` is 2D), this is a list aligned with portfolios.
+
+    Notes
+    -----
+    All estimators should specify all parameters as explicit keyword arguments in
+    `__init__` (no `*args` or `**kwargs`), following scikit-learn conventions.
     """
 
     prior_estimator_: BasePrior
     distance_estimator_: BaseDistance
     hierarchical_clustering_estimator_: HierarchicalClustering
-    n_features_in_: int
-    feature_names_in_: np.ndarray
 
     @abstractmethod
     def __init__(
@@ -226,8 +266,15 @@ class BaseHierarchicalOptimization(BaseOptimization, ABC):
         management_fees: skt.MultiInput = 0.0,
         previous_weights: skt.MultiInput | None = None,
         portfolio_params: dict | None = None,
+        fallback: skt.Fallback = None,
+        raise_on_failure: bool = True,
     ):
-        super().__init__(portfolio_params=portfolio_params)
+        super().__init__(
+            portfolio_params=portfolio_params,
+            fallback=fallback,
+            previous_weights=previous_weights,
+            raise_on_failure=raise_on_failure,
+        )
         self.risk_measure = risk_measure
         self.prior_estimator = prior_estimator
         self.distance_estimator = distance_estimator
@@ -236,7 +283,6 @@ class BaseHierarchicalOptimization(BaseOptimization, ABC):
         self.max_weights = max_weights
         self.transaction_costs = transaction_costs
         self.management_fees = management_fees
-        self.previous_weights = previous_weights
         self._seriated = False
 
     def _clean_input(

--- a/src/skfolio/optimization/cluster/hierarchical/_herc.py
+++ b/src/skfolio/optimization/cluster/hierarchical/_herc.py
@@ -249,22 +249,23 @@ class HierarchicalEqualRiskContribution(BaseHierarchicalOptimization):
         attributes are propagated to the portfolio by default: `name`,
         `transaction_costs`, `management_fees`, `previous_weights` and `risk_free_rate`.
 
-    fallback : BaseOptimization | list[BaseOptimization] | "previous_weights", optional
+    fallback : BaseOptimization | "previous_weights" | list[BaseOptimization | "previous_weights"], optional
         Fallback estimator or a list of estimators to try, in order, when the primary
-        optimization raises during `fit`. When a fallback succeeds, its fitted
-        `weights_` are copied back to the primary estimator so that `fit` still returns
-        the original instance. For traceability, `fallback_` stores the successful
-        estimator (or the string `"previous_weights"`), and `fallback_chain_` stores
-        each attempt with the associated outcome.
+        optimization raises during `fit`. Alternatively, use `"previous_weights"` 
+        (alone or in a list) to fall back to the estimator's `previous_weights`.
+        When a fallback succeeds, its fitted `weights_` are copied back to the primary 
+        estimator so that `fit` still returns the original instance. For traceability, 
+        `fallback_` stores the successful estimator (or the string `"previous_weights"`)
+         and `fallback_chain_` stores each attempt with the associated outcome.
 
     raise_on_failure : bool, default=True
         Controls error handling when fitting fails.
-        - If True: failures during `fit` are raised and no `weights_` are set.
-          Subsequent calls to `predict` will raise a not-fitted error.
-        - If False: errors are not raised; a warning is emitted and `weights_` is set to
-          `None`. Subsequent calls to `predict` will return a `FailedPortfolio`.
-        When fallbacks are specified, this behavior applies only after all fallbacks are
-        exhausted.
+        If True, any failure during `fit` is raised immediately, no `weights_` are
+        set and subsequent calls to `predict` will raise a `NotFittedError`.
+        If False, errors are not raised; instead, a warning is emitted, `weights_`
+        is set to `None` and subsequent calls to `predict` will return a
+        `FailedPortfolio`. When fallbacks are specified, this behavior applies only
+        after all fallbacks have been exhausted.
 
     Attributes
     ----------

--- a/src/skfolio/optimization/cluster/hierarchical/_herc.py
+++ b/src/skfolio/optimization/cluster/hierarchical/_herc.py
@@ -5,6 +5,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Weight constraints is a novel implementation, see docstring for more details.
 
+from __future__ import annotations
+
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
@@ -225,12 +227,8 @@ class HierarchicalEqualRiskContribution(BaseHierarchicalOptimization):
         (asset name/asset previous weight) and the input `X` of the `fit` method must
         be a DataFrame with the asset names in columns.
         The default (`None`) means no previous weights.
-
-    portfolio_params :  dict, optional
-        Portfolio parameters passed to the portfolio evaluated by the `predict` and
-        `score` methods. If not provided, the `name`, `transaction_costs`,
-        `management_fees`, `previous_weights` and `risk_free_rate` are copied from the
-        optimization model and passed to the portfolio.
+        Additionally, when `fallback="previous_weights"`, failures will fall back to
+        these weights if provided.
 
     solver : str, default="CLARABEL"
         The solver used for the weights constraints optimization. The default is
@@ -244,6 +242,29 @@ class HierarchicalEqualRiskContribution(BaseHierarchicalOptimization):
         The default (`None`) is to use the CVXPY default.
         For more details about solver arguments, check the CVXPY documentation:
         https://www.cvxpy.org/tutorial/advanced/index.html#setting-solver-options
+
+    portfolio_params : dict, optional
+        Portfolio parameters forwarded to the resulting `Portfolio` in `predict`.
+        If not provided and if available on the estimator, the following
+        attributes are propagated to the portfolio by default: `name`,
+        `transaction_costs`, `management_fees`, `previous_weights` and `risk_free_rate`.
+
+    fallback : BaseOptimization | list[BaseOptimization] | "previous_weights", optional
+        Fallback estimator or a list of estimators to try, in order, when the primary
+        optimization raises during `fit`. When a fallback succeeds, its fitted
+        `weights_` are copied back to the primary estimator so that `fit` still returns
+        the original instance. For traceability, `fallback_` stores the successful
+        estimator (or the string `"previous_weights"`), and `fallback_chain_` stores
+        each attempt with the associated outcome.
+
+    raise_on_failure : bool, default=True
+        Controls error handling when fitting fails.
+        - If True: failures during `fit` are raised and no `weights_` are set.
+          Subsequent calls to `predict` will raise a not-fitted error.
+        - If False: errors are not raised; a warning is emitted and `weights_` is set to
+          `None`. Subsequent calls to `predict` will return a `FailedPortfolio`.
+        When fallbacks are specified, this behavior applies only after all fallbacks are
+        exhausted.
 
     Attributes
     ----------
@@ -262,6 +283,27 @@ class HierarchicalEqualRiskContribution(BaseHierarchicalOptimization):
     feature_names_in_ : ndarray of shape (`n_features_in_`,)
         Names of assets seen during `fit`. Defined only when `X`
         has asset names that are all strings.
+
+    fallback_ : BaseOptimization | "previous_weights" | None
+        The fallback estimator instance, or the string `"previous_weights"`, that
+        produced the final result. `None` if no fallback was used.
+
+    fallback_chain_ : list[tuple[str, str]] | None
+        Sequence describing the optimization fallback attempts. Each element is a
+        pair `(estimator_repr, outcome)` where `estimator_repr` is the string
+        representation of the primary estimator or a fallback (e.g. `"EqualWeighted()"`,
+        `"previous_weights"`), and `outcome` is `"success"` if that step produced
+        a valid solution, otherwise the stringified error message. For successful
+        fits without any fallback, this is `None`.
+
+    error_ : str | list[str] | None
+        Captured error message(s) when `fit` fails. For multi-portfolio outputs
+        (`weights_` is 2D), this is a list aligned with portfolios.
+
+    Notes
+    -----
+    All estimators should specify all parameters as explicit keyword arguments in
+    `__init__` (no `*args` or `**kwargs`), following scikit-learn conventions.
 
     References
     ----------
@@ -294,6 +336,8 @@ class HierarchicalEqualRiskContribution(BaseHierarchicalOptimization):
         management_fees: skt.MultiInput = 0.0,
         previous_weights: skt.MultiInput | None = None,
         portfolio_params: dict | None = None,
+        fallback: skt.Fallback = None,
+        raise_on_failure: bool = True,
     ):
         super().__init__(
             risk_measure=risk_measure,
@@ -306,13 +350,15 @@ class HierarchicalEqualRiskContribution(BaseHierarchicalOptimization):
             management_fees=management_fees,
             previous_weights=previous_weights,
             portfolio_params=portfolio_params,
+            fallback=fallback,
+            raise_on_failure=raise_on_failure,
         )
         self.solver = solver
         self.solver_params = solver_params
 
     def fit(
         self, X: npt.ArrayLike, y: None = None, **fit_params
-    ) -> "HierarchicalEqualRiskContribution":
+    ) -> HierarchicalEqualRiskContribution:
         """Fit the Hierarchical Equal Risk Contribution estimator.
 
         Parameters

--- a/src/skfolio/optimization/cluster/hierarchical/_hrp.py
+++ b/src/skfolio/optimization/cluster/hierarchical/_hrp.py
@@ -6,6 +6,8 @@
 # The risk measure generalization and constraint features are derived
 # from Riskfolio-Lib, Copyright (c) 2020-2023, Dany Cajas, Licensed under BSD 3 clause.
 
+from __future__ import annotations
+
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
@@ -199,12 +201,31 @@ class HierarchicalRiskParity(BaseHierarchicalOptimization):
         (asset name/asset previous weight) and the input `X` of the `fit` method must
         be a DataFrame with the asset names in columns.
         The default (`None`) means no previous weights.
+        Additionally, when `fallback="previous_weights"`, failures will fall back to
+        these weights if provided.
 
-    portfolio_params :  dict, optional
-        Portfolio parameters passed to the portfolio evaluated by the `predict` and
-        `score` methods. If not provided, the `name`, `transaction_costs`,
-        `management_fees`, `previous_weights` and `risk_free_rate` are copied from the
-        optimization model and passed to the portfolio.
+    portfolio_params : dict, optional
+        Portfolio parameters forwarded to the resulting `Portfolio` in `predict`.
+        If not provided and if available on the estimator, the following
+        attributes are propagated to the portfolio by default: `name`,
+        `transaction_costs`, `management_fees`, `previous_weights` and `risk_free_rate`.
+
+    fallback : BaseOptimization | list[BaseOptimization] | "previous_weights", optional
+        Fallback estimator or a list of estimators to try, in order, when the primary
+        optimization raises during `fit`. When a fallback succeeds, its fitted
+        `weights_` are copied back to the primary estimator so that `fit` still returns
+        the original instance. For traceability, `fallback_` stores the successful
+        estimator (or the string `"previous_weights"`), and `fallback_chain_` stores
+        each attempt with the associated outcome.
+
+    raise_on_failure : bool, default=True
+        Controls error handling when fitting fails.
+        - If True: failures during `fit` are raised and no `weights_` are set.
+          Subsequent calls to `predict` will raise a not-fitted error.
+        - If False: errors are not raised; a warning is emitted and `weights_` is set to
+          `None`. Subsequent calls to `predict` will return a `FailedPortfolio`.
+        When fallbacks are specified, this behavior applies only after all fallbacks are
+        exhausted.
 
     Attributes
     ----------
@@ -223,6 +244,27 @@ class HierarchicalRiskParity(BaseHierarchicalOptimization):
     feature_names_in_ : ndarray of shape (`n_features_in_`,)
         Names of assets seen during `fit`. Defined only when `X`
         has asset names that are all strings.
+
+    fallback_ : BaseOptimization | "previous_weights" | None
+        The fallback estimator instance, or the string `"previous_weights"`, that
+        produced the final result. `None` if no fallback was used.
+
+    fallback_chain_ : list[tuple[str, str]] | None
+        Sequence describing the optimization fallback attempts. Each element is a
+        pair `(estimator_repr, outcome)` where `estimator_repr` is the string
+        representation of the primary estimator or a fallback (e.g. `"EqualWeighted()"`,
+        `"previous_weights"`), and `outcome` is `"success"` if that step produced
+        a valid solution, otherwise the stringified error message. For successful
+        fits without any fallback, this is `None`.
+
+    error_ : str | list[str] | None
+        Captured error message(s) when `fit` fails. For multi-portfolio outputs
+        (`weights_` is 2D), this is a list aligned with portfolios.
+
+    Notes
+    -----
+    All estimators should specify all parameters as explicit keyword arguments in
+    `__init__` (no `*args` or `**kwargs`), following scikit-learn conventions.
 
     References
     ----------
@@ -255,6 +297,8 @@ class HierarchicalRiskParity(BaseHierarchicalOptimization):
         management_fees: skt.MultiInput = 0.0,
         previous_weights: skt.MultiInput | None = None,
         portfolio_params: dict | None = None,
+        fallback: skt.Fallback = None,
+        raise_on_failure: bool = True,
     ):
         super().__init__(
             risk_measure=risk_measure,
@@ -267,11 +311,13 @@ class HierarchicalRiskParity(BaseHierarchicalOptimization):
             management_fees=management_fees,
             previous_weights=previous_weights,
             portfolio_params=portfolio_params,
+            fallback=fallback,
+            raise_on_failure=raise_on_failure,
         )
 
     def fit(
         self, X: npt.ArrayLike, y: None = None, **fit_params
-    ) -> "HierarchicalRiskParity":
+    ) -> HierarchicalRiskParity:
         """Fit the Hierarchical Risk Parity Optimization estimator.
 
         Parameters

--- a/src/skfolio/optimization/cluster/hierarchical/_hrp.py
+++ b/src/skfolio/optimization/cluster/hierarchical/_hrp.py
@@ -210,22 +210,23 @@ class HierarchicalRiskParity(BaseHierarchicalOptimization):
         attributes are propagated to the portfolio by default: `name`,
         `transaction_costs`, `management_fees`, `previous_weights` and `risk_free_rate`.
 
-    fallback : BaseOptimization | list[BaseOptimization] | "previous_weights", optional
+    fallback : BaseOptimization | "previous_weights" | list[BaseOptimization | "previous_weights"], optional
         Fallback estimator or a list of estimators to try, in order, when the primary
-        optimization raises during `fit`. When a fallback succeeds, its fitted
-        `weights_` are copied back to the primary estimator so that `fit` still returns
-        the original instance. For traceability, `fallback_` stores the successful
-        estimator (or the string `"previous_weights"`), and `fallback_chain_` stores
-        each attempt with the associated outcome.
+        optimization raises during `fit`. Alternatively, use `"previous_weights"` 
+        (alone or in a list) to fall back to the estimator's `previous_weights`.
+        When a fallback succeeds, its fitted `weights_` are copied back to the primary 
+        estimator so that `fit` still returns the original instance. For traceability, 
+        `fallback_` stores the successful estimator (or the string `"previous_weights"`)
+         and `fallback_chain_` stores each attempt with the associated outcome.
 
     raise_on_failure : bool, default=True
         Controls error handling when fitting fails.
-        - If True: failures during `fit` are raised and no `weights_` are set.
-          Subsequent calls to `predict` will raise a not-fitted error.
-        - If False: errors are not raised; a warning is emitted and `weights_` is set to
-          `None`. Subsequent calls to `predict` will return a `FailedPortfolio`.
-        When fallbacks are specified, this behavior applies only after all fallbacks are
-        exhausted.
+        If True, any failure during `fit` is raised immediately, no `weights_` are
+        set and subsequent calls to `predict` will raise a `NotFittedError`.
+        If False, errors are not raised; instead, a warning is emitted, `weights_`
+        is set to `None` and subsequent calls to `predict` will return a
+        `FailedPortfolio`. When fallbacks are specified, this behavior applies only
+        after all fallbacks have been exhausted.
 
     Attributes
     ----------

--- a/src/skfolio/optimization/cluster/hierarchical/_schur.py
+++ b/src/skfolio/optimization/cluster/hierarchical/_schur.py
@@ -185,22 +185,23 @@ class SchurComplementary(BaseHierarchicalOptimization):
         attributes are propagated to the portfolio by default: `name`,
         `transaction_costs`, `management_fees`, `previous_weights` and `risk_free_rate`.
 
-    fallback : BaseOptimization | list[BaseOptimization] | "previous_weights", optional
+    fallback : BaseOptimization | "previous_weights" | list[BaseOptimization | "previous_weights"], optional
         Fallback estimator or a list of estimators to try, in order, when the primary
-        optimization raises during `fit`. When a fallback succeeds, its fitted
-        `weights_` are copied back to the primary estimator so that `fit` still returns
-        the original instance. For traceability, `fallback_` stores the successful
-        estimator (or the string `"previous_weights"`), and `fallback_chain_` stores
-        each attempt with the associated outcome.
+        optimization raises during `fit`. Alternatively, use `"previous_weights"` 
+        (alone or in a list) to fall back to the estimator's `previous_weights`.
+        When a fallback succeeds, its fitted `weights_` are copied back to the primary 
+        estimator so that `fit` still returns the original instance. For traceability, 
+        `fallback_` stores the successful estimator (or the string `"previous_weights"`)
+         and `fallback_chain_` stores each attempt with the associated outcome.
 
     raise_on_failure : bool, default=True
         Controls error handling when fitting fails.
-        - If True: failures during `fit` are raised and no `weights_` are set.
-          Subsequent calls to `predict` will raise a not-fitted error.
-        - If False: errors are not raised; a warning is emitted and `weights_` is set to
-          `None`. Subsequent calls to `predict` will return a `FailedPortfolio`.
-        When fallbacks are specified, this behavior applies only after all fallbacks are
-        exhausted.
+        If True, any failure during `fit` is raised immediately, no `weights_` are
+        set and subsequent calls to `predict` will raise a `NotFittedError`.
+        If False, errors are not raised; instead, a warning is emitted, `weights_`
+        is set to `None` and subsequent calls to `predict` will return a
+        `FailedPortfolio`. When fallbacks are specified, this behavior applies only
+        after all fallbacks have been exhausted.
 
     Attributes
     ----------
@@ -239,11 +240,6 @@ class SchurComplementary(BaseHierarchicalOptimization):
     error_ : str | list[str] | None
         Captured error message(s) when `fit` fails. For multi-portfolio outputs
         (`weights_` is 2D), this is a list aligned with portfolios.
-
-    Notes
-    -----
-    All estimators should specify all parameters as explicit keyword arguments in
-    `__init__` (no `*args` or `**kwargs`), following scikit-learn conventions.
 
     References
     ----------

--- a/src/skfolio/optimization/cluster/hierarchical/_schur.py
+++ b/src/skfolio/optimization/cluster/hierarchical/_schur.py
@@ -13,6 +13,8 @@
 # factor gamma, we identify the variance turning point and cap gamma at its maximum
 # permissible value. See https://github.com/skfolio/skfolio/discussions/3
 
+from __future__ import annotations
+
 import math
 from collections.abc import Callable
 
@@ -174,12 +176,31 @@ class SchurComplementary(BaseHierarchicalOptimization):
         (asset name/asset previous weight) and the input `X` of the `fit` method must
         be a DataFrame with the asset names in columns.
         The default (`None`) means no previous weights.
+        Additionally, when `fallback="previous_weights"`, failures will fall back to
+        these weights if provided.
 
-    portfolio_params :  dict, optional
-        Portfolio parameters passed to the portfolio evaluated by the `predict` and
-        `score` methods. If not provided, the `name`, `transaction_costs`,
-        `management_fees` and `previous_weights` are copied from the optimization
-        model and systematically passed to the portfolio.
+    portfolio_params : dict, optional
+        Portfolio parameters forwarded to the resulting `Portfolio` in `predict`.
+        If not provided and if available on the estimator, the following
+        attributes are propagated to the portfolio by default: `name`,
+        `transaction_costs`, `management_fees`, `previous_weights` and `risk_free_rate`.
+
+    fallback : BaseOptimization | list[BaseOptimization] | "previous_weights", optional
+        Fallback estimator or a list of estimators to try, in order, when the primary
+        optimization raises during `fit`. When a fallback succeeds, its fitted
+        `weights_` are copied back to the primary estimator so that `fit` still returns
+        the original instance. For traceability, `fallback_` stores the successful
+        estimator (or the string `"previous_weights"`), and `fallback_chain_` stores
+        each attempt with the associated outcome.
+
+    raise_on_failure : bool, default=True
+        Controls error handling when fitting fails.
+        - If True: failures during `fit` are raised and no `weights_` are set.
+          Subsequent calls to `predict` will raise a not-fitted error.
+        - If False: errors are not raised; a warning is emitted and `weights_` is set to
+          `None`. Subsequent calls to `predict` will return a `FailedPortfolio`.
+        When fallbacks are specified, this behavior applies only after all fallbacks are
+        exhausted.
 
     Attributes
     ----------
@@ -202,6 +223,27 @@ class SchurComplementary(BaseHierarchicalOptimization):
     feature_names_in_ : ndarray of shape (`n_features_in_`,)
         Names of assets seen during `fit`. Defined only when `X`
         has asset names that are all strings.
+
+    fallback_ : BaseOptimization | "previous_weights" | None
+        The fallback estimator instance, or the string `"previous_weights"`, that
+        produced the final result. `None` if no fallback was used.
+
+    fallback_chain_ : list[tuple[str, str]] | None
+        Sequence describing the optimization fallback attempts. Each element is a
+        pair `(estimator_repr, outcome)` where `estimator_repr` is the string
+        representation of the primary estimator or a fallback (e.g. `"EqualWeighted()"`,
+        `"previous_weights"`), and `outcome` is `"success"` if that step produced
+        a valid solution, otherwise the stringified error message. For successful
+        fits without any fallback, this is `None`.
+
+    error_ : str | list[str] | None
+        Captured error message(s) when `fit` fails. For multi-portfolio outputs
+        (`weights_` is 2D), this is a list aligned with portfolios.
+
+    Notes
+    -----
+    All estimators should specify all parameters as explicit keyword arguments in
+    `__init__` (no `*args` or `**kwargs`), following scikit-learn conventions.
 
     References
     ----------
@@ -280,6 +322,8 @@ class SchurComplementary(BaseHierarchicalOptimization):
         management_fees: skt.MultiInput = 0.0,
         previous_weights: skt.MultiInput | None = None,
         portfolio_params: dict | None = None,
+        fallback: skt.Fallback = None,
+        raise_on_failure: bool = True,
     ):
         super().__init__(
             prior_estimator=prior_estimator,
@@ -291,13 +335,13 @@ class SchurComplementary(BaseHierarchicalOptimization):
             management_fees=management_fees,
             previous_weights=previous_weights,
             portfolio_params=portfolio_params,
+            fallback=fallback,
+            raise_on_failure=raise_on_failure,
         )
         self.gamma = gamma
         self.keep_monotonic = keep_monotonic
 
-    def fit(
-        self, X: npt.ArrayLike, y: None = None, **fit_params
-    ) -> "SchurComplementary":
+    def fit(self, X: npt.ArrayLike, y: None = None, **fit_params) -> SchurComplementary:
         """Fit the Schur Complementary estimator.
 
         Parameters

--- a/src/skfolio/optimization/convex/_base.py
+++ b/src/skfolio/optimization/convex/_base.py
@@ -439,22 +439,23 @@ class ConvexOptimization(BaseOptimization, ABC):
         attributes are propagated to the portfolio by default: `name`,
         `transaction_costs`, `management_fees`, `previous_weights` and `risk_free_rate`.
 
-    fallback : BaseOptimization | list[BaseOptimization] | "previous_weights", optional
+    fallback : BaseOptimization | "previous_weights" | list[BaseOptimization | "previous_weights"], optional
         Fallback estimator or a list of estimators to try, in order, when the primary
-        optimization raises during `fit`. When a fallback succeeds, its fitted
-        `weights_` are copied back to the primary estimator so that `fit` still returns
-        the original instance. For traceability, `fallback_` stores the successful
-        estimator (or the string `"previous_weights"`), and `fallback_chain_` stores
-        each attempt with the associated outcome.
+        optimization raises during `fit`. Alternatively, use `"previous_weights"` 
+        (alone or in a list) to fall back to the estimator's `previous_weights`.
+        When a fallback succeeds, its fitted `weights_` are copied back to the primary 
+        estimator so that `fit` still returns the original instance. For traceability, 
+        `fallback_` stores the successful estimator (or the string `"previous_weights"`)
+         and `fallback_chain_` stores each attempt with the associated outcome.
 
     raise_on_failure : bool, default=True
         Controls error handling when fitting fails.
-        - If True: failures during `fit` are raised and no `weights_` are set.
-          Subsequent calls to `predict` will raise a not-fitted error.
-        - If False: errors are not raised; a warning is emitted and `weights_` is set to
-          `None`. Subsequent calls to `predict` will return a `FailedPortfolio`.
-        When fallbacks are specified, this behavior applies only after all fallbacks are
-        exhausted.
+        If True, any failure during `fit` is raised immediately, no `weights_` are
+        set and subsequent calls to `predict` will raise a `NotFittedError`.
+        If False, errors are not raised; instead, a warning is emitted, `weights_`
+        is set to `None` and subsequent calls to `predict` will return a
+        `FailedPortfolio`. When fallbacks are specified, this behavior applies only
+        after all fallbacks have been exhausted.
 
     Attributes
     ----------

--- a/src/skfolio/optimization/convex/_base.py
+++ b/src/skfolio/optimization/convex/_base.py
@@ -6,10 +6,11 @@
 # The optimization features are derived
 # from Riskfolio-Lib, Copyright (c) 2020-2023, Dany Cajas, Licensed under BSD 3 clause.
 
+from __future__ import annotations
+
 import warnings
 from abc import ABC, abstractmethod
 from enum import auto
-from typing import Any
 
 import cvxpy as cp
 import cvxpy.constraints.constraint as cpc
@@ -21,6 +22,7 @@ import sklearn.utils.metadata_routing as skm
 from cvxpy.reductions.solvers.defines import MI_SOLVERS
 
 import skfolio.typing as skt
+from skfolio._constants import _ParamKey
 from skfolio.measures import RiskMeasure, owa_gmd_weights
 from skfolio.optimization._base import BaseOptimization
 from skfolio.prior import BasePrior, ReturnDistribution
@@ -272,6 +274,8 @@ class ConvexOptimization(BaseOptimization, ABC):
         (asset name/asset previous weight) and the input `X` of the `fit` method must
         be a DataFrame with the assets names in columns.
         The default (`None`) means no previous weights.
+        Additionally, when `fallback="previous_weights"`, failures will fall back to
+        these weights if provided.
 
     l1_coef : float, default=0.0
         L1 regularization coefficient.
@@ -429,15 +433,28 @@ class ConvexOptimization(BaseOptimization, ABC):
         If this is set to True, the CVXPY Problem is saved in `problem_`.
         The default is `False`.
 
-    raise_on_failure : bool, default=True
-        If this is set to True, an error is raised when the optimization fail otherwise
-        it passes with a warning.
+    portfolio_params : dict, optional
+        Portfolio parameters forwarded to the resulting `Portfolio` in `predict`.
+        If not provided and if available on the estimator, the following
+        attributes are propagated to the portfolio by default: `name`,
+        `transaction_costs`, `management_fees`, `previous_weights` and `risk_free_rate`.
 
-    portfolio_params :  dict, optional
-        Portfolio parameters passed to the portfolio evaluated by the `predict` and
-        `score` methods. If not provided, the `name`, `transaction_costs`,
-        `management_fees`, `previous_weights` and `risk_free_rate` are copied from the
-        optimization model and passed to the portfolio.
+    fallback : BaseOptimization | list[BaseOptimization] | "previous_weights", optional
+        Fallback estimator or a list of estimators to try, in order, when the primary
+        optimization raises during `fit`. When a fallback succeeds, its fitted
+        `weights_` are copied back to the primary estimator so that `fit` still returns
+        the original instance. For traceability, `fallback_` stores the successful
+        estimator (or the string `"previous_weights"`), and `fallback_chain_` stores
+        each attempt with the associated outcome.
+
+    raise_on_failure : bool, default=True
+        Controls error handling when fitting fails.
+        - If True: failures during `fit` are raised and no `weights_` are set.
+          Subsequent calls to `predict` will raise a not-fitted error.
+        - If False: errors are not raised; a warning is emitted and `weights_` is set to
+          `None`. Subsequent calls to `predict` will return a `FailedPortfolio`.
+        When fallbacks are specified, this behavior applies only after all fallbacks are
+        exhausted.
 
     Attributes
     ----------
@@ -459,6 +476,27 @@ class ConvexOptimization(BaseOptimization, ABC):
     problem_: cvxpy.Problem
         CVXPY problem used for the optimization. Only when `save_problem` is set to
         `True`.
+
+    fallback_ : BaseOptimization | "previous_weights" | None
+        The fallback estimator instance, or the string `"previous_weights"`, that
+        produced the final result. `None` if no fallback was used.
+
+    fallback_chain_ : list[tuple[str, str]] | None
+        Sequence describing the optimization fallback attempts. Each element is a
+        pair `(estimator_repr, outcome)` where `estimator_repr` is the string
+        representation of the primary estimator or a fallback (e.g. `"EqualWeighted()"`,
+        `"previous_weights"`), and `outcome` is `"success"` if that step produced
+        a valid solution, otherwise the stringified error message. For successful
+        fits without any fallback, this is `None`.
+
+    error_ : str | list[str] | None
+        Captured error message(s) when `fit` fails. For multi-portfolio outputs
+        (`weights_` is 2D), this is a list aligned with portfolios.
+
+    Notes
+    -----
+    All estimators should specify all parameters as explicit keyword arguments in
+    `__init__` (no `*args` or `**kwargs`), following scikit-learn conventions.
     """
 
     _solver_params: dict
@@ -512,13 +550,19 @@ class ConvexOptimization(BaseOptimization, ABC):
         scale_objective: float | None = None,
         scale_constraints: float | None = None,
         save_problem: bool = False,
-        raise_on_failure: bool = True,
         add_objective: skt.ExpressionFunction | None = None,
         add_constraints: skt.ExpressionFunction | None = None,
         overwrite_expected_return: skt.ExpressionFunction | None = None,
         portfolio_params: dict | None = None,
+        fallback: skt.Fallback = None,
+        raise_on_failure: bool = True,
     ):
-        super().__init__(portfolio_params=portfolio_params)
+        super().__init__(
+            previous_weights=previous_weights,
+            portfolio_params=portfolio_params,
+            fallback=fallback,
+            raise_on_failure=raise_on_failure,
+        )
         if risk_measure.is_annualized:
             warnings.warn(
                 f"The annualized risk measure {risk_measure} will be converted"
@@ -544,7 +588,6 @@ class ConvexOptimization(BaseOptimization, ABC):
         self.min_acceptable_return = min_acceptable_return
         self.transaction_costs = transaction_costs
         self.management_fees = management_fees
-        self.previous_weights = previous_weights
         self.groups = groups
         self.linear_constraints = linear_constraints
         self.left_inequality = left_inequality
@@ -558,7 +601,6 @@ class ConvexOptimization(BaseOptimization, ABC):
         self.solver = solver
         self.solver_params = solver_params
         self.save_problem = save_problem
-        self.raise_on_failure = raise_on_failure
         self.scale_objective = scale_objective
         self.scale_constraints = scale_constraints
         self.cvar_beta = cvar_beta
@@ -611,50 +653,6 @@ class ConvexOptimization(BaseOptimization, ABC):
                 f"{name} must be a function taking as argument "
                 "the weight variable OR the weight variable and the estimator object."
             ) from err
-
-    def _clean_input(
-        self,
-        value: float | dict | npt.ArrayLike | None,
-        n_assets: int,
-        fill_value: Any,
-        name: str,
-    ) -> float | np.ndarray:
-        """Convert input to cleaned float or ndarray.
-
-        Parameters
-        ----------
-        value : float, dict, array-like or None.
-            Input value to clean.
-
-        n_assets : int
-            Number of assets. Used to verify the shape of the converted array.
-
-        fill_value : Any
-            When `items` is a dictionary, elements that are not in `asset_names` are
-            filled with `fill_value` in the converted array.
-
-        name : str
-            Name used for error messages.
-
-        Returns
-        -------
-        value :  float or ndarray of shape (n_assets,)
-            The cleaned float or 1D array.
-        """
-        if value is None:
-            return fill_value
-        if np.isscalar(value):
-            return float(value)
-        return input_to_array(
-            items=value,
-            n_assets=n_assets,
-            fill_value=fill_value,
-            dim=1,
-            assets_names=(
-                self.feature_names_in_ if hasattr(self, "feature_names_in_") else None
-            ),
-            name=name,
-        )
 
     def _clear_models_cache(self):
         """CLear the cache of CVX models."""
@@ -1108,74 +1106,62 @@ class ConvexOptimization(BaseOptimization, ABC):
                 for p, v in parameters_values
             ]
 
-        all_weights = []
-        all_problem_values = []
-        optimal = True
-        for i in range(n_optimizations):
-            for parameter, values in parameters_values:
-                parameter.value = values[i]
-
-            try:
-                # We suppress cvxpy warning as it is redundant with our warning
-                with warnings.catch_warnings():
-                    warnings.simplefilter("ignore")
-                    problem.solve(solver=self.solver, **self._solver_params)
-
-                if w.value is None:
-                    raise cp.SolverError("No solution found")
-
-                weights = w.value / factor.value
-                problem_values = {
-                    name: expression.value / factor.value
-                    if name != "factor"
-                    else expression.value
-                    for name, expression in expressions.items()
-                }
-                problem_values["objective"] = (
-                    problem.value / self._scale_objective.value
-                )
-
-                if (
-                    self.risk_measure
-                    in [RiskMeasure.VARIANCE, RiskMeasure.SEMI_VARIANCE]
-                    and "risk" in problem_values
-                ):
-                    problem_values["risk"] /= factor.value
-
-                all_problem_values.append(problem_values)
-                all_weights.append(np.array(weights, dtype=float))
-
-                if problem.status != cp.OPTIMAL:
-                    optimal = False
-            except (cp.SolverError, scl.ArpackNoConvergence):
-                params_string = " ".join(
-                    [f"{p.value:0g}" for p in problem.parameters()]
-                )
-                if len(params_string) != 0:
-                    params_string = f" with parameters {params_string}"
-                msg = (
-                    f"Solver '{self.solver}' failed{params_string}. Try another"
-                    " solver, or solve with solver_params=dict(verbose=True) for more"
-                    " information"
-                )
-                if self.raise_on_failure:
-                    raise cp.SolverError(msg) from None
-                else:
-                    warnings.warn(msg, stacklevel=2)
-
-        if not optimal:
-            warnings.warn(
-                "Solution may be inaccurate. Try changing the solver params or the"
-                " scale. For more details, set `solver_params=dict(verbose=True)`",
-                stacklevel=2,
-            )
-
         if n_optimizations == 1:
-            self.weights_ = all_weights[0]
-            self.problem_values_ = all_problem_values[0]
+            for parameter, values in parameters_values:
+                parameter.value = values[0]
+
+            self.weights_, self.problem_values_ = _solve(
+                w=w,
+                factor=factor,
+                expressions=expressions,
+                problem=problem,
+                solver=self.solver,
+                solver_params=self._solver_params,
+                risk_measure=self.risk_measure,
+                scale_objective=self._scale_objective,
+            )
         else:
-            self.weights_ = np.array(all_weights, dtype=float)
+            all_weights = []
+            all_problem_values = []
+            all_errors = []
+            with warnings.catch_warnings():
+                warnings.simplefilter("once", UserWarning)
+                for i in range(n_optimizations):
+                    for parameter, values in parameters_values:
+                        parameter.value = values[i]
+
+                    try:
+                        weights, problem_values = _solve(
+                            w=w,
+                            factor=factor,
+                            expressions=expressions,
+                            problem=problem,
+                            solver=self.solver,
+                            solver_params=self._solver_params,
+                            risk_measure=self.risk_measure,
+                            scale_objective=self._scale_objective,
+                        )
+                        error = None
+                    except cp.SolverError as solver_error:
+                        if self.raise_on_failure:
+                            raise
+                        error = str(solver_error)
+                        warnings.warn(error, stacklevel=2)
+                        problem_values = None
+                        weights = np.full(w.shape, np.nan, dtype=float)
+
+                    all_problem_values.append(problem_values)
+                    all_weights.append(weights)
+                    all_errors.append(error)
+
+            all_weights = np.array(all_weights, dtype=float)
+            if np.isnan(all_weights).all():
+                raise cp.SolverError(
+                    f"All {n_optimizations} optimizations failed, with last optimization error {all_errors[-1]}"
+                )
+            self.weights_ = all_weights
             self.problem_values_ = all_problem_values
+            self.error_ = all_errors
 
         if self.save_problem:
             self.problem_ = problem
@@ -1265,19 +1251,12 @@ class ConvexOptimization(BaseOptimization, ABC):
             self.transaction_costs,
             n_assets=n_assets,
             fill_value=0,
-            name="transaction_costs",
+            name=_ParamKey.TRANSACTION_COSTS.value,
         )
         if np.all(transaction_costs == 0):
             return cp.Constant(0)
 
-        previous_weights = self._clean_input(
-            self.previous_weights,
-            n_assets=n_assets,
-            fill_value=0,
-            name="previous_weights",
-        )
-        if np.isscalar(previous_weights):
-            previous_weights *= np.ones(n_assets)
+        previous_weights = self._clean_previous_weights(n_assets=n_assets)
 
         if np.isscalar(transaction_costs):
             return transaction_costs * cp.norm(previous_weights * factor - w, 1)
@@ -1311,7 +1290,7 @@ class ConvexOptimization(BaseOptimization, ABC):
             self.management_fees,
             n_assets=n_assets,
             fill_value=0,
-            name="management_fees",
+            name=_ParamKey.MANAGEMENT_FEES.value,
         )
         if np.all(management_fees == 0):
             return cp.Constant(0)
@@ -1374,7 +1353,7 @@ class ConvexOptimization(BaseOptimization, ABC):
             self.previous_weights,
             n_assets=n_assets,
             fill_value=0,
-            name="previous_weights",
+            name=_ParamKey.PREVIOUS_WEIGHTS.value,
         )
         if np.isscalar(previous_weights):
             previous_weights *= np.ones(n_assets)
@@ -2395,3 +2374,62 @@ def _mip_weight_constraints_threshold_short(
     ]
 
     return constraints
+
+
+def _solve(
+    w,
+    factor,
+    expressions,
+    problem,
+    solver,
+    solver_params,
+    risk_measure,
+    scale_objective,
+):
+    try:
+        # We suppress cvxpy warning as it is redundant with our warning
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            problem.solve(solver=solver, **solver_params)
+
+        if w.value is None:
+            raise cp.SolverError("No solution found")
+
+        weights = w.value / factor.value
+        problem_values = {
+            name: expression.value / factor.value
+            if name != "factor"
+            else expression.value
+            for name, expression in expressions.items()
+        }
+        problem_values["objective"] = problem.value / scale_objective.value
+
+        if (
+            risk_measure in [RiskMeasure.VARIANCE, RiskMeasure.SEMI_VARIANCE]
+            and "risk" in problem_values
+        ):
+            problem_values["risk"] /= factor.value
+
+        weights = np.array(weights, dtype=float)
+        if not problem.status == cp.OPTIMAL:
+            warnings.warn(
+                "Solution may be inaccurate. Try changing the solver params or the"
+                " scale. For more details, set `solver_params=dict(verbose=True)`",
+                stacklevel=2,
+            )
+        return weights, problem_values
+    except (cp.SolverError, scl.ArpackNoConvergence):
+        params_string = " ".join([f"{p.value:0g}" for p in problem.parameters()])
+        if len(params_string) != 0:
+            params_string = f" with parameters {params_string}"
+        error = (
+            f"Solver '{solver}' failed{params_string}. Try another"
+            " solver, or solve with solver_params=dict(verbose=True) for more"
+            " information"
+        )
+        raise cp.SolverError(error) from None
+        # elif n_optimizations > 1:
+        #     warnings.warn(error, stacklevel=2)
+        #
+        # problem_values = None
+        # weights = np.full(w.shape, np.nan, dtype=float)

--- a/src/skfolio/optimization/convex/_distributionally_robust.py
+++ b/src/skfolio/optimization/convex/_distributionally_robust.py
@@ -211,13 +211,14 @@ class DistributionallyRobustCVaR(ConvexOptimization):
         attributes are propagated to the portfolio by default: `name`,
         `transaction_costs`, `management_fees`, `previous_weights` and `risk_free_rate`.
 
-    fallback : BaseOptimization | list[BaseOptimization] | "previous_weights", optional
+    fallback : BaseOptimization | "previous_weights" | list[BaseOptimization | "previous_weights"], optional
         Fallback estimator or a list of estimators to try, in order, when the primary
-        optimization raises during `fit`. When a fallback succeeds, its fitted
-        `weights_` are copied back to the primary estimator so that `fit` still returns
-        the original instance. For traceability, `fallback_` stores the successful
-        estimator (or the string `"previous_weights"`), and `fallback_chain_` stores
-        each attempt with the associated outcome.
+        optimization raises during `fit`. Alternatively, use `"previous_weights"` 
+        (alone or in a list) to fall back to the estimator's `previous_weights`.
+        When a fallback succeeds, its fitted `weights_` are copied back to the primary 
+        estimator so that `fit` still returns the original instance. For traceability, 
+        `fallback_` stores the successful estimator (or the string `"previous_weights"`)
+         and `fallback_chain_` stores each attempt with the associated outcome.
 
     previous_weights : float | dict[str, float] | array-like of shape (n_assets,), optional
         When `fallback="previous_weights"`, failures will fall back to these weights if
@@ -225,12 +226,12 @@ class DistributionallyRobustCVaR(ConvexOptimization):
 
     raise_on_failure : bool, default=True
         Controls error handling when fitting fails.
-        - If True: failures during `fit` are raised and no `weights_` are set.
-          Subsequent calls to `predict` will raise a not-fitted error.
-        - If False: errors are not raised; a warning is emitted and `weights_` is set to
-          `None`. Subsequent calls to `predict` will return a `FailedPortfolio`.
-        When fallbacks are specified, this behavior applies only after all fallbacks are
-        exhausted.
+        If True, any failure during `fit` is raised immediately, no `weights_` are
+        set and subsequent calls to `predict` will raise a `NotFittedError`.
+        If False, errors are not raised; instead, a warning is emitted, `weights_`
+        is set to `None` and subsequent calls to `predict` will return a
+        `FailedPortfolio`. When fallbacks are specified, this behavior applies only
+        after all fallbacks have been exhausted.
 
     Attributes
     ----------

--- a/src/skfolio/optimization/convex/_distributionally_robust.py
+++ b/src/skfolio/optimization/convex/_distributionally_robust.py
@@ -4,6 +4,8 @@
 # Author: Hugo Delatte <delatte.hugo@gmail.com>
 # SPDX-License-Identifier: BSD-3-Clause
 
+from __future__ import annotations
+
 import cvxpy as cp
 import numpy as np
 import numpy.typing as npt
@@ -203,15 +205,32 @@ class DistributionallyRobustCVaR(ConvexOptimization):
         If this is set to True, the CVXPY Problem is saved in `problem_`.
         The default is `False`.
 
-    raise_on_failure : bool, default=True
-        If this is set to True, an error is raised when the optimization fail otherwise
-        it passes with a warning.
+    portfolio_params : dict, optional
+        Portfolio parameters forwarded to the resulting `Portfolio` in `predict`.
+        If not provided and if available on the estimator, the following
+        attributes are propagated to the portfolio by default: `name`,
+        `transaction_costs`, `management_fees`, `previous_weights` and `risk_free_rate`.
 
-    portfolio_params :  dict, optional
-        Portfolio parameters passed to the portfolio evaluated by the `predict` and
-        `score` methods. If not provided, the `name`, `transaction_costs`,
-        `management_fees`, `previous_weights` and `risk_free_rate` are copied from the
-        optimization model and passed to the portfolio.
+    fallback : BaseOptimization | list[BaseOptimization] | "previous_weights", optional
+        Fallback estimator or a list of estimators to try, in order, when the primary
+        optimization raises during `fit`. When a fallback succeeds, its fitted
+        `weights_` are copied back to the primary estimator so that `fit` still returns
+        the original instance. For traceability, `fallback_` stores the successful
+        estimator (or the string `"previous_weights"`), and `fallback_chain_` stores
+        each attempt with the associated outcome.
+
+    previous_weights : float | dict[str, float] | array-like of shape (n_assets,), optional
+        When `fallback="previous_weights"`, failures will fall back to these weights if
+        provided.
+
+    raise_on_failure : bool, default=True
+        Controls error handling when fitting fails.
+        - If True: failures during `fit` are raised and no `weights_` are set.
+          Subsequent calls to `predict` will raise a not-fitted error.
+        - If False: errors are not raised; a warning is emitted and `weights_` is set to
+          `None`. Subsequent calls to `predict` will return a `FailedPortfolio`.
+        When fallbacks are specified, this behavior applies only after all fallbacks are
+        exhausted.
 
     Attributes
     ----------
@@ -234,6 +253,27 @@ class DistributionallyRobustCVaR(ConvexOptimization):
     feature_names_in_ : ndarray of shape (`n_features_in_`,)
         Names of assets seen during `fit`. Defined only when `X`
         has assets names that are all strings.
+
+    fallback_ : BaseOptimization | "previous_weights" | None
+        The fallback estimator instance, or the string `"previous_weights"`, that
+        produced the final result. `None` if no fallback was used.
+
+    fallback_chain_ : list[tuple[str, str]] | None
+        Sequence describing the optimization fallback attempts. Each element is a
+        pair `(estimator_repr, outcome)` where `estimator_repr` is the string
+        representation of the primary estimator or a fallback (e.g. `"EqualWeighted()"`,
+        `"previous_weights"`), and `outcome` is `"success"` if that step produced
+        a valid solution, otherwise the stringified error message. For successful
+        fits without any fallback, this is `None`.
+
+    error_ : str | list[str] | None
+        Captured error message(s) when `fit` fails. For multi-portfolio outputs
+        (`weights_` is 2D), this is a list aligned with portfolios.
+
+    Notes
+    -----
+    All estimators should specify all parameters as explicit keyword arguments in
+    `__init__` (no `*args` or `**kwargs`), following scikit-learn conventions.
 
     References
     ----------
@@ -268,11 +308,13 @@ class DistributionallyRobustCVaR(ConvexOptimization):
         scale_objective: float | None = None,
         scale_constraints: float | None = None,
         save_problem: bool = False,
-        raise_on_failure: bool = True,
         add_objective: skt.ExpressionFunction | None = None,
         add_constraints: skt.ExpressionFunction | None = None,
         overwrite_expected_return: skt.ExpressionFunction | None = None,
         portfolio_params: dict | None = None,
+        fallback: skt.Fallback = None,
+        previous_weights: skt.MultiInput | None = None,
+        raise_on_failure: bool = True,
     ):
         super().__init__(
             risk_measure=RiskMeasure.CVAR,
@@ -295,18 +337,20 @@ class DistributionallyRobustCVaR(ConvexOptimization):
             scale_objective=scale_objective,
             scale_constraints=scale_constraints,
             save_problem=save_problem,
-            raise_on_failure=raise_on_failure,
             add_objective=add_objective,
             add_constraints=add_constraints,
             overwrite_expected_return=overwrite_expected_return,
             portfolio_params=portfolio_params,
+            fallback=fallback,
+            previous_weights=previous_weights,
+            raise_on_failure=raise_on_failure,
         )
         self.risk_aversion = risk_aversion
         self.wasserstein_ball_radius = wasserstein_ball_radius
 
     def fit(
         self, X: npt.ArrayLike, y: npt.ArrayLike | None = None, **fit_params
-    ) -> "DistributionallyRobustCVaR":
+    ) -> DistributionallyRobustCVaR:
         """Fit the Distributionally Robust CVaR Optimization estimator.
 
         Parameters

--- a/src/skfolio/optimization/convex/_maximum_diversification.py
+++ b/src/skfolio/optimization/convex/_maximum_diversification.py
@@ -4,6 +4,8 @@
 # Author: Hugo Delatte <delatte.hugo@gmail.com>
 # SPDX-License-Identifier: BSD-3-Clause
 
+from __future__ import annotations
+
 import numpy as np
 import numpy.typing as npt
 import sklearn.utils.validation as skv
@@ -175,6 +177,8 @@ class MaximumDiversification(MeanRisk):
         (asset name/asset previous weight) and the input `X` of the `fit` method must
         be a DataFrame with the assets names in columns.
         The default (`None`) means no previous weights.
+        Additionally, when `fallback="previous_weights"`, failures will fall back to
+        these weights if provided.
 
     l1_coef : float, default=0.0
         L1 regularization coefficient.
@@ -294,15 +298,28 @@ class MaximumDiversification(MeanRisk):
         If this is set to True, the CVXPY Problem is saved in `problem_`.
         The default is `False`.
 
-    raise_on_failure : bool, default=True
-        If this is set to True, an error is raised when the optimization fail otherwise
-        it passes with a warning.
+    portfolio_params : dict, optional
+        Portfolio parameters forwarded to the resulting `Portfolio` in `predict`.
+        If not provided and if available on the estimator, the following
+        attributes are propagated to the portfolio by default: `name`,
+        `transaction_costs`, `management_fees`, `previous_weights` and `risk_free_rate`.
 
-    portfolio_params :  dict, optional
-        Portfolio parameters passed to the portfolio evaluated by the `predict` and
-        `score` methods. If not provided, the `name`, `transaction_costs`,
-        `management_fees`, `previous_weights` and `risk_free_rate` are copied from the
-        optimization model and passed to the portfolio.
+    fallback : BaseOptimization | list[BaseOptimization] | "previous_weights", optional
+        Fallback estimator or a list of estimators to try, in order, when the primary
+        optimization raises during `fit`. When a fallback succeeds, its fitted
+        `weights_` are copied back to the primary estimator so that `fit` still returns
+        the original instance. For traceability, `fallback_` stores the successful
+        estimator (or the string `"previous_weights"`), and `fallback_chain_` stores
+        each attempt with the associated outcome.
+
+    raise_on_failure : bool, default=True
+        Controls error handling when fitting fails.
+        - If True: failures during `fit` are raised and no `weights_` are set.
+          Subsequent calls to `predict` will raise a not-fitted error.
+        - If False: errors are not raised; a warning is emitted and `weights_` is set to
+          `None`. Subsequent calls to `predict` will return a `FailedPortfolio`.
+        When fallbacks are specified, this behavior applies only after all fallbacks are
+        exhausted.
 
     Attributes
     ----------
@@ -325,6 +342,27 @@ class MaximumDiversification(MeanRisk):
     feature_names_in_ : ndarray of shape (`n_features_in_`,)
         Names of assets seen during `fit`. Defined only when `X`
         has assets names that are all strings.
+
+    fallback_ : BaseOptimization | "previous_weights" | None
+        The fallback estimator instance, or the string `"previous_weights"`, that
+        produced the final result. `None` if no fallback was used.
+
+    fallback_chain_ : list[tuple[str, str]] | None
+        Sequence describing the optimization fallback attempts. Each element is a
+        pair `(estimator_repr, outcome)` where `estimator_repr` is the string
+        representation of the primary estimator or a fallback (e.g. `"EqualWeighted()"`,
+        `"previous_weights"`), and `outcome` is `"success"` if that step produced
+        a valid solution, otherwise the stringified error message. For successful
+        fits without any fallback, this is `None`.
+
+    error_ : str | list[str] | None
+        Captured error message(s) when `fit` fails. For multi-portfolio outputs
+        (`weights_` is 2D), this is a list aligned with portfolios.
+
+    Notes
+    -----
+    All estimators should specify all parameters as explicit keyword arguments in
+    `__init__` (no `*args` or `**kwargs`), following scikit-learn conventions.
     """
 
     def __init__(
@@ -355,10 +393,11 @@ class MaximumDiversification(MeanRisk):
         scale_objective: float | None = None,
         scale_constraints: float | None = None,
         save_problem: bool = False,
-        raise_on_failure: bool = True,
         add_objective: skt.ExpressionFunction | None = None,
         add_constraints: skt.ExpressionFunction | None = None,
         portfolio_params: dict | None = None,
+        fallback: skt.Fallback = None,
+        raise_on_failure: bool = True,
     ):
         super().__init__(
             objective_function=ObjectiveFunction.MAXIMIZE_RATIO,
@@ -389,15 +428,16 @@ class MaximumDiversification(MeanRisk):
             scale_objective=scale_objective,
             scale_constraints=scale_constraints,
             save_problem=save_problem,
-            raise_on_failure=raise_on_failure,
             add_objective=add_objective,
             add_constraints=add_constraints,
             portfolio_params=portfolio_params,
+            fallback=fallback,
+            raise_on_failure=raise_on_failure,
         )
 
     def fit(
         self, X: npt.ArrayLike, y: npt.ArrayLike | None = None, **fit_params
-    ) -> "MaximumDiversification":
+    ) -> MaximumDiversification:
         """Fit the Maximum Diversification Optimization estimator.
 
         Parameters

--- a/src/skfolio/optimization/convex/_maximum_diversification.py
+++ b/src/skfolio/optimization/convex/_maximum_diversification.py
@@ -304,22 +304,23 @@ class MaximumDiversification(MeanRisk):
         attributes are propagated to the portfolio by default: `name`,
         `transaction_costs`, `management_fees`, `previous_weights` and `risk_free_rate`.
 
-    fallback : BaseOptimization | list[BaseOptimization] | "previous_weights", optional
+    fallback : BaseOptimization | "previous_weights" | list[BaseOptimization | "previous_weights"], optional
         Fallback estimator or a list of estimators to try, in order, when the primary
-        optimization raises during `fit`. When a fallback succeeds, its fitted
-        `weights_` are copied back to the primary estimator so that `fit` still returns
-        the original instance. For traceability, `fallback_` stores the successful
-        estimator (or the string `"previous_weights"`), and `fallback_chain_` stores
-        each attempt with the associated outcome.
+        optimization raises during `fit`. Alternatively, use `"previous_weights"` 
+        (alone or in a list) to fall back to the estimator's `previous_weights`.
+        When a fallback succeeds, its fitted `weights_` are copied back to the primary 
+        estimator so that `fit` still returns the original instance. For traceability, 
+        `fallback_` stores the successful estimator (or the string `"previous_weights"`)
+         and `fallback_chain_` stores each attempt with the associated outcome.
 
     raise_on_failure : bool, default=True
         Controls error handling when fitting fails.
-        - If True: failures during `fit` are raised and no `weights_` are set.
-          Subsequent calls to `predict` will raise a not-fitted error.
-        - If False: errors are not raised; a warning is emitted and `weights_` is set to
-          `None`. Subsequent calls to `predict` will return a `FailedPortfolio`.
-        When fallbacks are specified, this behavior applies only after all fallbacks are
-        exhausted.
+        If True, any failure during `fit` is raised immediately, no `weights_` are
+        set and subsequent calls to `predict` will raise a `NotFittedError`.
+        If False, errors are not raised; instead, a warning is emitted, `weights_`
+        is set to `None` and subsequent calls to `predict` will return a
+        `FailedPortfolio`. When fallbacks are specified, this behavior applies only
+        after all fallbacks have been exhausted.
 
     Attributes
     ----------

--- a/src/skfolio/optimization/convex/_mean_risk.py
+++ b/src/skfolio/optimization/convex/_mean_risk.py
@@ -1,12 +1,15 @@
 """Mean Risk Optimization estimator."""
 
-import warnings
-
 # Copyright (c) 2023
 # Author: Hugo Delatte <delatte.hugo@gmail.com>
 # SPDX-License-Identifier: BSD-3-Clause
 # The optimization features are derived
 # from Riskfolio-Lib, Copyright (c) 2020-2023, Dany Cajas, Licensed under BSD 3 clause.
+
+from __future__ import annotations
+
+import warnings
+
 import cvxpy as cp
 import numpy as np
 import numpy.typing as npt
@@ -22,7 +25,6 @@ from skfolio.prior import BasePrior, EmpiricalPrior
 from skfolio.uncertainty_set import BaseCovarianceUncertaintySet, BaseMuUncertaintySet
 from skfolio.utils.tools import args_names, check_estimator
 
-# noinspection PyUnresolvedReferences
 _NON_ANNUALIZED_RISK_MEASURES = [rm for rm in RiskMeasure if not rm.is_annualized]
 
 
@@ -322,6 +324,8 @@ class MeanRisk(ConvexOptimization):
         (asset name/asset previous weight) and the input `X` of the `fit` method must
         be a DataFrame with the assets names in columns.
         The default (`None`) means no previous weights.
+        Additionally, when `fallback="previous_weights"`, failures will fall back to
+        these weights if provided.
 
     l1_coef : float, default=0.0
         L1 regularization coefficient.
@@ -542,15 +546,28 @@ class MeanRisk(ConvexOptimization):
         If this is set to True, the CVXPY Problem is saved in `problem_`.
         The default is `False`.
 
-    raise_on_failure : bool, default=True
-        If this is set to True, an error is raised when the optimization fail otherwise
-        it passes with a warning.
+    portfolio_params : dict, optional
+        Portfolio parameters forwarded to the resulting `Portfolio` in `predict`.
+        If not provided and if available on the estimator, the following
+        attributes are propagated to the portfolio by default: `name`,
+        `transaction_costs`, `management_fees`, `previous_weights` and `risk_free_rate`.
 
-    portfolio_params :  dict, optional
-        Portfolio parameters passed to the portfolio evaluated by the `predict` and
-        `score` methods. If not provided, the `name`, `transaction_costs`,
-        `management_fees`, `previous_weights` and `risk_free_rate` are copied from the
-        optimization model and passed to the portfolio.
+    fallback : BaseOptimization | list[BaseOptimization] | "previous_weights", optional
+        Fallback estimator or a list of estimators to try, in order, when the primary
+        optimization raises during `fit`. When a fallback succeeds, its fitted
+        `weights_` are copied back to the primary estimator so that `fit` still returns
+        the original instance. For traceability, `fallback_` stores the successful
+        estimator (or the string `"previous_weights"`), and `fallback_chain_` stores
+        each attempt with the associated outcome.
+
+    raise_on_failure : bool, default=True
+        Controls error handling when fitting fails.
+        - If True: failures during `fit` are raised and no `weights_` are set.
+          Subsequent calls to `predict` will raise a not-fitted error.
+        - If False: errors are not raised; a warning is emitted and `weights_` is set to
+          `None`. Subsequent calls to `predict` will return a `FailedPortfolio`.
+        When fallbacks are specified, this behavior applies only after all fallbacks are
+        exhausted.
 
     Attributes
     ----------
@@ -579,6 +596,27 @@ class MeanRisk(ConvexOptimization):
     feature_names_in_ : ndarray of shape (`n_features_in_`,)
         Names of assets seen during `fit`. Defined only when `X`
         has assets names that are all strings.
+
+    fallback_ : BaseOptimization | "previous_weights" | None
+        The fallback estimator instance, or the string `"previous_weights"`, that
+        produced the final result. `None` if no fallback was used.
+
+    fallback_chain_ : list[tuple[str, str]] | None
+        Sequence describing the optimization fallback attempts. Each element is a
+        pair `(estimator_repr, outcome)` where `estimator_repr` is the string
+        representation of the primary estimator or a fallback (e.g. `"EqualWeighted()"`,
+        `"previous_weights"`), and `outcome` is `"success"` if that step produced
+        a valid solution, otherwise the stringified error message. For successful
+        fits without any fallback, this is `None`.
+
+    error_ : str | list[str] | None
+        Captured error message(s) when `fit` fails. For multi-portfolio outputs
+        (`weights_` is 2D), this is a list aligned with portfolios.
+
+    Notes
+    -----
+    All estimators should specify all parameters as explicit keyword arguments in
+    `__init__` (no `*args` or `**kwargs`), following scikit-learn conventions.
     """
 
     def __init__(
@@ -641,11 +679,12 @@ class MeanRisk(ConvexOptimization):
         scale_objective: float | None = None,
         scale_constraints: float | None = None,
         save_problem: bool = False,
-        raise_on_failure: bool = True,
         add_objective: skt.ExpressionFunction | None = None,
         add_constraints: skt.ExpressionFunction | None = None,
         overwrite_expected_return: skt.ExpressionFunction | None = None,
         portfolio_params: dict | None = None,
+        fallback: skt.Fallback = None,
+        raise_on_failure: bool = True,
     ):
         super().__init__(
             risk_measure=risk_measure,
@@ -683,11 +722,12 @@ class MeanRisk(ConvexOptimization):
             scale_objective=scale_objective,
             scale_constraints=scale_constraints,
             save_problem=save_problem,
-            raise_on_failure=raise_on_failure,
             add_objective=add_objective,
             add_constraints=add_constraints,
             overwrite_expected_return=overwrite_expected_return,
             portfolio_params=portfolio_params,
+            fallback=fallback,
+            raise_on_failure=raise_on_failure,
         )
         self.objective_function = objective_function
         self.risk_aversion = risk_aversion
@@ -746,7 +786,7 @@ class MeanRisk(ConvexOptimization):
 
     def fit(
         self, X: npt.ArrayLike, y: npt.ArrayLike | None = None, **fit_params
-    ) -> "MeanRisk":
+    ) -> MeanRisk:
         """Fit the Mean-Risk Optimization estimator.
 
         Parameters

--- a/src/skfolio/optimization/convex/_mean_risk.py
+++ b/src/skfolio/optimization/convex/_mean_risk.py
@@ -552,22 +552,23 @@ class MeanRisk(ConvexOptimization):
         attributes are propagated to the portfolio by default: `name`,
         `transaction_costs`, `management_fees`, `previous_weights` and `risk_free_rate`.
 
-    fallback : BaseOptimization | list[BaseOptimization] | "previous_weights", optional
+    fallback : BaseOptimization | "previous_weights" | list[BaseOptimization | "previous_weights"], optional
         Fallback estimator or a list of estimators to try, in order, when the primary
-        optimization raises during `fit`. When a fallback succeeds, its fitted
-        `weights_` are copied back to the primary estimator so that `fit` still returns
-        the original instance. For traceability, `fallback_` stores the successful
-        estimator (or the string `"previous_weights"`), and `fallback_chain_` stores
-        each attempt with the associated outcome.
+        optimization raises during `fit`. Alternatively, use `"previous_weights"` 
+        (alone or in a list) to fall back to the estimator's `previous_weights`.
+        When a fallback succeeds, its fitted `weights_` are copied back to the primary 
+        estimator so that `fit` still returns the original instance. For traceability, 
+        `fallback_` stores the successful estimator (or the string `"previous_weights"`)
+         and `fallback_chain_` stores each attempt with the associated outcome.
 
     raise_on_failure : bool, default=True
         Controls error handling when fitting fails.
-        - If True: failures during `fit` are raised and no `weights_` are set.
-          Subsequent calls to `predict` will raise a not-fitted error.
-        - If False: errors are not raised; a warning is emitted and `weights_` is set to
-          `None`. Subsequent calls to `predict` will return a `FailedPortfolio`.
-        When fallbacks are specified, this behavior applies only after all fallbacks are
-        exhausted.
+        If True, any failure during `fit` is raised immediately, no `weights_` are
+        set and subsequent calls to `predict` will raise a `NotFittedError`.
+        If False, errors are not raised; instead, a warning is emitted, `weights_`
+        is set to `None` and subsequent calls to `predict` will return a
+        `FailedPortfolio`. When fallbacks are specified, this behavior applies only
+        after all fallbacks have been exhausted.
 
     Attributes
     ----------

--- a/src/skfolio/optimization/convex/_risk_budgeting.py
+++ b/src/skfolio/optimization/convex/_risk_budgeting.py
@@ -341,22 +341,23 @@ class RiskBudgeting(ConvexOptimization):
         attributes are propagated to the portfolio by default: `name`,
         `transaction_costs`, `management_fees`, `previous_weights` and `risk_free_rate`.
 
-    fallback : BaseOptimization | list[BaseOptimization] | "previous_weights", optional
+    fallback : BaseOptimization | "previous_weights" | list[BaseOptimization | "previous_weights"], optional
         Fallback estimator or a list of estimators to try, in order, when the primary
-        optimization raises during `fit`. When a fallback succeeds, its fitted
-        `weights_` are copied back to the primary estimator so that `fit` still returns
-        the original instance. For traceability, `fallback_` stores the successful
-        estimator (or the string `"previous_weights"`), and `fallback_chain_` stores
-        each attempt with the associated outcome.
+        optimization raises during `fit`. Alternatively, use `"previous_weights"` 
+        (alone or in a list) to fall back to the estimator's `previous_weights`.
+        When a fallback succeeds, its fitted `weights_` are copied back to the primary 
+        estimator so that `fit` still returns the original instance. For traceability, 
+        `fallback_` stores the successful estimator (or the string `"previous_weights"`)
+         and `fallback_chain_` stores each attempt with the associated outcome.
 
     raise_on_failure : bool, default=True
         Controls error handling when fitting fails.
-        - If True: failures during `fit` are raised and no `weights_` are set.
-          Subsequent calls to `predict` will raise a not-fitted error.
-        - If False: errors are not raised; a warning is emitted and `weights_` is set to
-          `None`. Subsequent calls to `predict` will return a `FailedPortfolio`.
-        When fallbacks are specified, this behavior applies only after all fallbacks are
-        exhausted.
+        If True, any failure during `fit` is raised immediately, no `weights_` are
+        set and subsequent calls to `predict` will raise a `NotFittedError`.
+        If False, errors are not raised; instead, a warning is emitted, `weights_`
+        is set to `None` and subsequent calls to `predict` will return a
+        `FailedPortfolio`. When fallbacks are specified, this behavior applies only
+        after all fallbacks have been exhausted.
 
     Attributes
     ----------

--- a/src/skfolio/optimization/ensemble/_stacking.py
+++ b/src/skfolio/optimization/ensemble/_stacking.py
@@ -109,27 +109,27 @@ class StackingOptimization(BaseOptimization, BaseComposition):
         attributes are propagated to the portfolio by default: `name`,
         `transaction_costs`, `management_fees`, `previous_weights` and `risk_free_rate`.
 
-    fallback : BaseOptimization | list[BaseOptimization] | "previous_weights", optional
+    fallback : BaseOptimization | "previous_weights" | list[BaseOptimization | "previous_weights"], optional
         Fallback estimator or a list of estimators to try, in order, when the primary
-        optimization raises during `fit`. When a fallback succeeds, its fitted
-        `weights_` are copied back to the primary estimator so that `fit` still returns
-        the original instance. For traceability, `fallback_` stores the successful
-        estimator (or the string `"previous_weights"`), and `fallback_chain_` stores
-        each attempt with the associated outcome.
+        optimization raises during `fit`. Alternatively, use `"previous_weights"` 
+        (alone or in a list) to fall back to the estimator's `previous_weights`.
+        When a fallback succeeds, its fitted `weights_` are copied back to the primary 
+        estimator so that `fit` still returns the original instance. For traceability, 
+        `fallback_` stores the successful estimator (or the string `"previous_weights"`)
+         and `fallback_chain_` stores each attempt with the associated outcome.
 
     previous_weights : float | dict[str, float] | array-like of shape (n_assets,), optional
-        Previous asset weights. Some estimators use this to compute costs or turnover.
-        Additionally, when `fallback="previous_weights"`, failures will fall back to
-        these weights if provided.
+        When `fallback="previous_weights"`, failures will fall back to these weights
+        if provided.
 
     raise_on_failure : bool, default=True
         Controls error handling when fitting fails.
-        - If True: failures during `fit` are raised and no `weights_` are set.
-          Subsequent calls to `predict` will raise a not-fitted error.
-        - If False: errors are not raised; a warning is emitted and `weights_` is set to
-          `None`. Subsequent calls to `predict` will return a `FailedPortfolio`.
-        When fallbacks are specified, this behavior applies only after all fallbacks are
-        exhausted.
+        If True, any failure during `fit` is raised immediately, no `weights_` are
+        set and subsequent calls to `predict` will raise a `NotFittedError`.
+        If False, errors are not raised; instead, a warning is emitted, `weights_`
+        is set to `None` and subsequent calls to `predict` will return a
+        `FailedPortfolio`. When fallbacks are specified, this behavior applies only
+        after all fallbacks have been exhausted.
 
     Attributes
     ----------

--- a/src/skfolio/optimization/ensemble/_stacking.py
+++ b/src/skfolio/optimization/ensemble/_stacking.py
@@ -7,6 +7,8 @@
 # scikit-learn, Copyright (c) 2007-2010 David Cournapeau, Fabian Pedregosa, Olivier
 # Grisel Licensed under BSD 3 clause.
 
+from __future__ import annotations
+
 from copy import deepcopy
 
 import numpy as np
@@ -87,7 +89,6 @@ class StackingOptimization(BaseOptimization, BaseComposition):
         The value `-1` means using all processors.
         The default (`None`) means 1 unless in a `joblib.parallel_backend` context.
 
-
     quantile : float, default=0.5
         Quantile for a given measure (`quantile_measure`) of the out-of-sample
         inner-estimator paths when the `cv` parameter is a
@@ -102,10 +103,33 @@ class StackingOptimization(BaseOptimization, BaseComposition):
     verbose : int, default=0
         The verbosity level. The default value is `0`.
 
-    portfolio_params :  dict, optional
-        Portfolio parameters passed to the portfolio evaluated by the `predict` and
-        `score` methods. If not provided, the `name` is copied from the optimization
-        model and systematically passed to the portfolio.
+    portfolio_params : dict, optional
+        Portfolio parameters forwarded to the resulting `Portfolio` in `predict`.
+        If not provided and if available on the estimator, the following
+        attributes are propagated to the portfolio by default: `name`,
+        `transaction_costs`, `management_fees`, `previous_weights` and `risk_free_rate`.
+
+    fallback : BaseOptimization | list[BaseOptimization] | "previous_weights", optional
+        Fallback estimator or a list of estimators to try, in order, when the primary
+        optimization raises during `fit`. When a fallback succeeds, its fitted
+        `weights_` are copied back to the primary estimator so that `fit` still returns
+        the original instance. For traceability, `fallback_` stores the successful
+        estimator (or the string `"previous_weights"`), and `fallback_chain_` stores
+        each attempt with the associated outcome.
+
+    previous_weights : float | dict[str, float] | array-like of shape (n_assets,), optional
+        Previous asset weights. Some estimators use this to compute costs or turnover.
+        Additionally, when `fallback="previous_weights"`, failures will fall back to
+        these weights if provided.
+
+    raise_on_failure : bool, default=True
+        Controls error handling when fitting fails.
+        - If True: failures during `fit` are raised and no `weights_` are set.
+          Subsequent calls to `predict` will raise a not-fitted error.
+        - If False: errors are not raised; a warning is emitted and `weights_` is set to
+          `None`. Subsequent calls to `predict` will return a `FailedPortfolio`.
+        When fallbacks are specified, this behavior applies only after all fallbacks are
+        exhausted.
 
     Attributes
     ----------
@@ -129,6 +153,27 @@ class StackingOptimization(BaseOptimization, BaseComposition):
     feature_names_in_ : ndarray of shape (`n_features_in_`,)
         Names of assets seen during `fit`. Defined only when `X`
         has assets names that are all strings.
+
+    fallback_ : BaseOptimization | "previous_weights" | None
+        The fallback estimator instance, or the string `"previous_weights"`, that
+        produced the final result. `None` if no fallback was used.
+
+    fallback_chain_ : list[tuple[str, str]] | None
+        Sequence describing the optimization fallback attempts. Each element is a
+        pair `(estimator_repr, outcome)` where `estimator_repr` is the string
+        representation of the primary estimator or a fallback (e.g. `"EqualWeighted()"`,
+        `"previous_weights"`), and `outcome` is `"success"` if that step produced
+        a valid solution, otherwise the stringified error message. For successful
+        fits without any fallback, this is `None`.
+
+    error_ : str | list[str] | None
+        Captured error message(s) when `fit` fails. For multi-portfolio outputs
+        (`weights_` is 2D), this is a list aligned with portfolios.
+
+    Notes
+    -----
+    All estimators should specify all parameters as explicit keyword arguments in
+    `__init__` (no `*args` or `**kwargs`), following scikit-learn conventions.
     """
 
     estimators_: list[BaseOptimization]
@@ -145,8 +190,16 @@ class StackingOptimization(BaseOptimization, BaseComposition):
         n_jobs: int | None = None,
         verbose: int = 0,
         portfolio_params: dict | None = None,
+        fallback: skt.Fallback = None,
+        previous_weights: skt.MultiInput | None = None,
+        raise_on_failure: bool = True,
     ):
-        super().__init__(portfolio_params=portfolio_params)
+        super().__init__(
+            portfolio_params=portfolio_params,
+            fallback=fallback,
+            previous_weights=previous_weights,
+            raise_on_failure=raise_on_failure,
+        )
         self.estimators = estimators
         self.final_estimator = final_estimator
         self.cv = cv
@@ -242,7 +295,7 @@ class StackingOptimization(BaseOptimization, BaseComposition):
 
     def fit(
         self, X: npt.ArrayLike, y: npt.ArrayLike | None = None, **fit_params
-    ) -> "StackingOptimization":
+    ) -> StackingOptimization:
         """Fit the Stacking Optimization estimator.
 
         Parameters

--- a/src/skfolio/optimization/naive/_naive.py
+++ b/src/skfolio/optimization/naive/_naive.py
@@ -39,27 +39,27 @@ class InverseVolatility(BaseOptimization):
         attributes are propagated to the portfolio by default: `name`,
         and `previous_weights`.
 
-    fallback : BaseOptimization | list[BaseOptimization] | "previous_weights", optional
+    fallback : BaseOptimization | "previous_weights" | list[BaseOptimization | "previous_weights"], optional
         Fallback estimator or a list of estimators to try, in order, when the primary
-        optimization raises during `fit`. When a fallback succeeds, its fitted
-        `weights_` are copied back to the primary estimator so that `fit` still returns
-        the original instance. For traceability, `fallback_` stores the successful
-        estimator (or the string `"previous_weights"`), and `fallback_chain_` stores
-        each attempt with the associated outcome.
+        optimization raises during `fit`. Alternatively, use `"previous_weights"` 
+        (alone or in a list) to fall back to the estimator's `previous_weights`.
+        When a fallback succeeds, its fitted `weights_` are copied back to the primary 
+        estimator so that `fit` still returns the original instance. For traceability, 
+        `fallback_` stores the successful estimator (or the string `"previous_weights"`)
+         and `fallback_chain_` stores each attempt with the associated outcome.
 
     previous_weights : float | dict[str, float] | array-like of shape (n_assets,), optional
-        Previous asset weights. Some estimators use this to compute costs or turnover.
-        Additionally, when `fallback="previous_weights"`, failures will fall back to
-        these weights if provided.
+        When `fallback="previous_weights"`, failures will fall back to these weights
+        if provided.
 
     raise_on_failure : bool, default=True
         Controls error handling when fitting fails.
-        - If True: failures during `fit` are raised and no `weights_` are set.
-          Subsequent calls to `predict` will raise a not-fitted error.
-        - If False: errors are not raised; a warning is emitted and `weights_` is set to
-          `None`. Subsequent calls to `predict` will return a `FailedPortfolio`.
-        When fallbacks are specified, this behavior applies only after all fallbacks are
-        exhausted.
+        If True, any failure during `fit` is raised immediately, no `weights_` are
+        set and subsequent calls to `predict` will raise a `NotFittedError`.
+        If False, errors are not raised; instead, a warning is emitted, `weights_`
+        is set to `None` and subsequent calls to `predict` will return a
+        `FailedPortfolio`. When fallbacks are specified, this behavior applies only
+        after all fallbacks have been exhausted.
 
     Attributes
     ----------
@@ -171,27 +171,27 @@ class EqualWeighted(BaseOptimization):
         attributes are propagated to the portfolio by default: `name`,
         and `previous_weights`.
 
-    fallback : BaseOptimization | list[BaseOptimization] | "previous_weights", optional
+    fallback : BaseOptimization | "previous_weights" | list[BaseOptimization | "previous_weights"], optional
         Fallback estimator or a list of estimators to try, in order, when the primary
-        optimization raises during `fit`. When a fallback succeeds, its fitted
-        `weights_` are copied back to the primary estimator so that `fit` still returns
-        the original instance. For traceability, `fallback_` stores the successful
-        estimator (or the string `"previous_weights"`), and `fallback_chain_` stores
-        each attempt with the associated outcome.
+        optimization raises during `fit`. Alternatively, use `"previous_weights"` 
+        (alone or in a list) to fall back to the estimator's `previous_weights`.
+        When a fallback succeeds, its fitted `weights_` are copied back to the primary 
+        estimator so that `fit` still returns the original instance. For traceability, 
+        `fallback_` stores the successful estimator (or the string `"previous_weights"`)
+         and `fallback_chain_` stores each attempt with the associated outcome.
 
     previous_weights : float | dict[str, float] | array-like of shape (n_assets,), optional
-        Previous asset weights. Some estimators use this to compute costs or turnover.
-        Additionally, when `fallback="previous_weights"`, failures will fall back to
-        these weights if provided.
+        When `fallback="previous_weights"`, failures will fall back to these weights
+        if provided.
 
     raise_on_failure : bool, default=True
         Controls error handling when fitting fails.
-        - If True: failures during `fit` are raised and no `weights_` are set.
-          Subsequent calls to `predict` will raise a not-fitted error.
-        - If False: errors are not raised; a warning is emitted and `weights_` is set to
-          `None`. Subsequent calls to `predict` will return a `FailedPortfolio`.
-        When fallbacks are specified, this behavior applies only after all fallbacks are
-        exhausted.
+        If True, any failure during `fit` is raised immediately, no `weights_` are
+        set and subsequent calls to `predict` will raise a `NotFittedError`.
+        If False, errors are not raised; instead, a warning is emitted, `weights_`
+        is set to `None` and subsequent calls to `predict` will return a
+        `FailedPortfolio`. When fallbacks are specified, this behavior applies only
+        after all fallbacks have been exhausted.
 
     Attributes
     ----------
@@ -269,27 +269,27 @@ class Random(BaseOptimization):
         attributes are propagated to the portfolio by default: `name`,
         and `previous_weights`.
 
-    fallback : BaseOptimization | list[BaseOptimization] | "previous_weights", optional
+    fallback : BaseOptimization | "previous_weights" | list[BaseOptimization | "previous_weights"], optional
         Fallback estimator or a list of estimators to try, in order, when the primary
-        optimization raises during `fit`. When a fallback succeeds, its fitted
-        `weights_` are copied back to the primary estimator so that `fit` still returns
-        the original instance. For traceability, `fallback_` stores the successful
-        estimator (or the string `"previous_weights"`), and `fallback_chain_` stores
-        each attempt with the associated outcome.
+        optimization raises during `fit`. Alternatively, use `"previous_weights"` 
+        (alone or in a list) to fall back to the estimator's `previous_weights`.
+        When a fallback succeeds, its fitted `weights_` are copied back to the primary 
+        estimator so that `fit` still returns the original instance. For traceability, 
+        `fallback_` stores the successful estimator (or the string `"previous_weights"`)
+         and `fallback_chain_` stores each attempt with the associated outcome.
 
     previous_weights : float | dict[str, float] | array-like of shape (n_assets,), optional
-        Previous asset weights. Some estimators use this to compute costs or turnover.
-        Additionally, when `fallback="previous_weights"`, failures will fall back to
-        these weights if provided.
+        When `fallback="previous_weights"`, failures will fall back to these weights
+        if provided.
 
     raise_on_failure : bool, default=True
         Controls error handling when fitting fails.
-        - If True: failures during `fit` are raised and no `weights_` are set.
-          Subsequent calls to `predict` will raise a not-fitted error.
-        - If False: errors are not raised; a warning is emitted and `weights_` is set to
-          `None`. Subsequent calls to `predict` will return a `FailedPortfolio`.
-        When fallbacks are specified, this behavior applies only after all fallbacks are
-        exhausted.
+        If True, any failure during `fit` is raised immediately, no `weights_` are
+        set and subsequent calls to `predict` will raise a `NotFittedError`.
+        If False, errors are not raised; instead, a warning is emitted, `weights_`
+        is set to `None` and subsequent calls to `predict` will return a
+        `FailedPortfolio`. When fallbacks are specified, this behavior applies only
+        after all fallbacks have been exhausted.
 
     Attributes
     ----------

--- a/src/skfolio/optimization/naive/_naive.py
+++ b/src/skfolio/optimization/naive/_naive.py
@@ -3,11 +3,14 @@
 # Author: Hugo Delatte <delatte.hugo@gmail.com>
 # SPDX-License-Identifier: BSD-3-Clause
 
+from __future__ import annotations
+
 import numpy as np
 import numpy.typing as npt
 import sklearn.utils.metadata_routing as skm
 import sklearn.utils.validation as skv
 
+import skfolio.typing as skt
 from skfolio.optimization._base import BaseOptimization
 from skfolio.prior import BasePrior, EmpiricalPrior
 from skfolio.utils.stats import rand_weights_dirichlet
@@ -30,11 +33,33 @@ class InverseVolatility(BaseOptimization):
         returns and Cholesky decomposition of the covariance.
         The default (`None`) is to use :class:`~skfolio.prior.EmpiricalPrior`.
 
-    portfolio_params :  dict, optional
-        Portfolio parameters passed to the portfolio evaluated by the `predict` and
-        `score` methods. If not provided, the `name`, `transaction_costs`,
-        `management_fees`, `previous_weights` and `risk_free_rate` are copied from the
-        optimization model and passed to the portfolio.
+    portfolio_params : dict, optional
+        Portfolio parameters forwarded to the resulting `Portfolio` in `predict`.
+        If not provided and if available on the estimator, the following
+        attributes are propagated to the portfolio by default: `name`,
+        and `previous_weights`.
+
+    fallback : BaseOptimization | list[BaseOptimization] | "previous_weights", optional
+        Fallback estimator or a list of estimators to try, in order, when the primary
+        optimization raises during `fit`. When a fallback succeeds, its fitted
+        `weights_` are copied back to the primary estimator so that `fit` still returns
+        the original instance. For traceability, `fallback_` stores the successful
+        estimator (or the string `"previous_weights"`), and `fallback_chain_` stores
+        each attempt with the associated outcome.
+
+    previous_weights : float | dict[str, float] | array-like of shape (n_assets,), optional
+        Previous asset weights. Some estimators use this to compute costs or turnover.
+        Additionally, when `fallback="previous_weights"`, failures will fall back to
+        these weights if provided.
+
+    raise_on_failure : bool, default=True
+        Controls error handling when fitting fails.
+        - If True: failures during `fit` are raised and no `weights_` are set.
+          Subsequent calls to `predict` will raise a not-fitted error.
+        - If False: errors are not raised; a warning is emitted and `weights_` is set to
+          `None`. Subsequent calls to `predict` will return a `FailedPortfolio`.
+        When fallbacks are specified, this behavior applies only after all fallbacks are
+        exhausted.
 
     Attributes
     ----------
@@ -43,6 +68,27 @@ class InverseVolatility(BaseOptimization):
 
     prior_estimator_ : BasePrior
         Fitted `prior_estimator`.
+
+    fallback_ : BaseOptimization | "previous_weights" | None
+        The fallback estimator instance, or the string `"previous_weights"`, that
+        produced the final result. `None` if no fallback was used.
+
+    fallback_chain_ : list[tuple[str, str]] | None
+        Sequence describing the optimization fallback attempts. Each element is a
+        pair `(estimator_repr, outcome)` where `estimator_repr` is the string
+        representation of the primary estimator or a fallback (e.g. `"EqualWeighted()"`,
+        `"previous_weights"`), and `outcome` is `"success"` if that step produced
+        a valid solution, otherwise the stringified error message. For successful
+        fits without any fallback, this is `None`.
+
+    error_ : str | list[str] | None
+        Captured error message(s) when `fit` fails. For multi-portfolio outputs
+        (`weights_` is 2D), this is a list aligned with portfolios.
+
+    Notes
+    -----
+    All estimators should specify all parameters as explicit keyword arguments in
+    `__init__` (no `*args` or `**kwargs`), following scikit-learn conventions.
     """
 
     prior_estimator_: BasePrior
@@ -51,8 +97,16 @@ class InverseVolatility(BaseOptimization):
         self,
         prior_estimator: BasePrior | None = None,
         portfolio_params: dict | None = None,
+        fallback: skt.Fallback = None,
+        previous_weights: skt.MultiInput | None = None,
+        raise_on_failure: bool = True,
     ):
-        super().__init__(portfolio_params=portfolio_params)
+        super().__init__(
+            portfolio_params=portfolio_params,
+            fallback=fallback,
+            previous_weights=previous_weights,
+            raise_on_failure=raise_on_failure,
+        )
         self.prior_estimator = prior_estimator
 
     def get_metadata_routing(self):
@@ -65,7 +119,7 @@ class InverseVolatility(BaseOptimization):
 
     def fit(
         self, X: npt.ArrayLike, y: npt.ArrayLike | None = None, **fit_params
-    ) -> "InverseVolatility":
+    ) -> InverseVolatility:
         """Fit the Inverse Volatility estimator.
 
         Parameters
@@ -111,22 +165,76 @@ class EqualWeighted(BaseOptimization):
 
     Parameters
     ----------
-    portfolio_params :  dict, optional
-        Portfolio parameters passed to the portfolio evaluated by the `predict` and
-        `score` methods. If not provided, the `name`, `transaction_costs`,
-        `management_fees`, `previous_weights` and `risk_free_rate` are copied from the
-        optimization model and passed to the portfolio.
+    portfolio_params : dict, optional
+        Portfolio parameters forwarded to the resulting `Portfolio` in `predict`.
+        If not provided and if available on the estimator, the following
+        attributes are propagated to the portfolio by default: `name`,
+        and `previous_weights`.
+
+    fallback : BaseOptimization | list[BaseOptimization] | "previous_weights", optional
+        Fallback estimator or a list of estimators to try, in order, when the primary
+        optimization raises during `fit`. When a fallback succeeds, its fitted
+        `weights_` are copied back to the primary estimator so that `fit` still returns
+        the original instance. For traceability, `fallback_` stores the successful
+        estimator (or the string `"previous_weights"`), and `fallback_chain_` stores
+        each attempt with the associated outcome.
+
+    previous_weights : float | dict[str, float] | array-like of shape (n_assets,), optional
+        Previous asset weights. Some estimators use this to compute costs or turnover.
+        Additionally, when `fallback="previous_weights"`, failures will fall back to
+        these weights if provided.
+
+    raise_on_failure : bool, default=True
+        Controls error handling when fitting fails.
+        - If True: failures during `fit` are raised and no `weights_` are set.
+          Subsequent calls to `predict` will raise a not-fitted error.
+        - If False: errors are not raised; a warning is emitted and `weights_` is set to
+          `None`. Subsequent calls to `predict` will return a `FailedPortfolio`.
+        When fallbacks are specified, this behavior applies only after all fallbacks are
+        exhausted.
 
     Attributes
     ----------
     weights_ : ndarray of shape (n_assets,) or (n_optimizations, n_assets)
         Weights of the assets.
+
+    fallback_ : BaseOptimization | "previous_weights" | None
+        The fallback estimator instance, or the string `"previous_weights"`, that
+        produced the final result. `None` if no fallback was used.
+
+    fallback_chain_ : list[tuple[str, str]] | None
+        Sequence describing the optimization fallback attempts. Each element is a
+        pair `(estimator_repr, outcome)` where `estimator_repr` is the string
+        representation of the primary estimator or a fallback (e.g. `"EqualWeighted()"`,
+        `"previous_weights"`), and `outcome` is `"success"` if that step produced
+        a valid solution, otherwise the stringified error message. For successful
+        fits without any fallback, this is `None`.
+
+    error_ : str | list[str] | None
+        Captured error message(s) when `fit` fails. For multi-portfolio outputs
+        (`weights_` is 2D), this is a list aligned with portfolios.
+
+    Notes
+    -----
+    All estimators should specify all parameters as explicit keyword arguments in
+    `__init__` (no `*args` or `**kwargs`), following scikit-learn conventions.
     """
 
-    def __init__(self, portfolio_params: dict | None = None):
-        super().__init__(portfolio_params=portfolio_params)
+    def __init__(
+        self,
+        portfolio_params: dict | None = None,
+        fallback: skt.Fallback = None,
+        previous_weights: skt.MultiInput | None = None,
+        raise_on_failure: bool = True,
+    ):
+        super().__init__(
+            portfolio_params=portfolio_params,
+            fallback=fallback,
+            previous_weights=previous_weights,
+            raise_on_failure=raise_on_failure,
+        )
 
-    def fit(self, X: npt.ArrayLike, y=None) -> "EqualWeighted":
+    def fit(self, X: npt.ArrayLike, y=None) -> EqualWeighted:
         """Fit the Equal Weighted estimator.
 
         Parameters
@@ -155,20 +263,74 @@ class Random(BaseOptimization):
 
     Parameters
     ----------
-    portfolio_params :  dict, optional
-        Portfolio parameters passed to the portfolio evaluated by the `predict` and
-        `score` methods. If not provided, the `name`, `transaction_costs`,
-        `management_fees`, `previous_weights` and `risk_free_rate` are copied from the
-        optimization model and passed to the portfolio.
+    portfolio_params : dict, optional
+        Portfolio parameters forwarded to the resulting `Portfolio` in `predict`.
+        If not provided and if available on the estimator, the following
+        attributes are propagated to the portfolio by default: `name`,
+        and `previous_weights`.
+
+    fallback : BaseOptimization | list[BaseOptimization] | "previous_weights", optional
+        Fallback estimator or a list of estimators to try, in order, when the primary
+        optimization raises during `fit`. When a fallback succeeds, its fitted
+        `weights_` are copied back to the primary estimator so that `fit` still returns
+        the original instance. For traceability, `fallback_` stores the successful
+        estimator (or the string `"previous_weights"`), and `fallback_chain_` stores
+        each attempt with the associated outcome.
+
+    previous_weights : float | dict[str, float] | array-like of shape (n_assets,), optional
+        Previous asset weights. Some estimators use this to compute costs or turnover.
+        Additionally, when `fallback="previous_weights"`, failures will fall back to
+        these weights if provided.
+
+    raise_on_failure : bool, default=True
+        Controls error handling when fitting fails.
+        - If True: failures during `fit` are raised and no `weights_` are set.
+          Subsequent calls to `predict` will raise a not-fitted error.
+        - If False: errors are not raised; a warning is emitted and `weights_` is set to
+          `None`. Subsequent calls to `predict` will return a `FailedPortfolio`.
+        When fallbacks are specified, this behavior applies only after all fallbacks are
+        exhausted.
 
     Attributes
     ----------
     weights_ : ndarray of shape (n_assets,) or (n_optimizations, n_assets)
         Weights of the assets.
+
+    fallback_ : BaseOptimization | "previous_weights" | None
+        The fallback estimator instance, or the string `"previous_weights"`, that
+        produced the final result. `None` if no fallback was used.
+
+    fallback_chain_ : list[tuple[str, str]] | None
+        Sequence describing the optimization fallback attempts. Each element is a
+        pair `(estimator_repr, outcome)` where `estimator_repr` is the string
+        representation of the primary estimator or a fallback (e.g. `"EqualWeighted()"`,
+        `"previous_weights"`), and `outcome` is `"success"` if that step produced
+        a valid solution, otherwise the stringified error message. For successful
+        fits without any fallback, this is `None`.
+
+    error_ : str | list[str] | None
+        Captured error message(s) when `fit` fails. For multi-portfolio outputs
+        (`weights_` is 2D), this is a list aligned with portfolios.
+
+    Notes
+    -----
+    All estimators should specify all parameters as explicit keyword arguments in
+    `__init__` (no `*args` or `**kwargs`), following scikit-learn conventions.
     """
 
-    def __init__(self, portfolio_params: dict | None = None):
-        super().__init__(portfolio_params=portfolio_params)
+    def __init__(
+        self,
+        portfolio_params: dict | None = None,
+        fallback: skt.Fallback = None,
+        previous_weights: skt.MultiInput | None = None,
+        raise_on_failure: bool = True,
+    ):
+        super().__init__(
+            portfolio_params=portfolio_params,
+            fallback=fallback,
+            previous_weights=previous_weights,
+            raise_on_failure=raise_on_failure,
+        )
 
     def fit(self, X: npt.ArrayLike, y=None):
         """Fit the Random Weighted estimator.

--- a/src/skfolio/portfolio/__init__.py
+++ b/src/skfolio/portfolio/__init__.py
@@ -7,7 +7,8 @@ is the dot product of the assets weights with the assets returns and
 """
 
 from skfolio.portfolio._base import BasePortfolio
+from skfolio.portfolio._failed_portfolio import FailedPortfolio
 from skfolio.portfolio._multi_period_portfolio import MultiPeriodPortfolio
 from skfolio.portfolio._portfolio import Portfolio
 
-__all__ = ["BasePortfolio", "MultiPeriodPortfolio", "Portfolio"]
+__all__ = ["BasePortfolio", "FailedPortfolio", "MultiPeriodPortfolio", "Portfolio"]

--- a/src/skfolio/portfolio/_base.py
+++ b/src/skfolio/portfolio/_base.py
@@ -50,6 +50,7 @@ import scipy.stats as st
 
 import skfolio.typing as skt
 from skfolio import measures as mt
+from skfolio._constants import _ParamKey
 from skfolio.measures import (
     ExtraRiskMeasure,
     PerfMeasure,
@@ -380,7 +381,7 @@ class BasePortfolio:
         "drawdowns",
         "min_acceptable_return",
         "compounded",
-        "risk_free_rate",
+        _ParamKey.RISK_FREE_RATE.value,
         "sample_weight",
     }
 

--- a/src/skfolio/portfolio/_base.py
+++ b/src/skfolio/portfolio/_base.py
@@ -20,7 +20,7 @@
 #     * Public (read and right)
 #     * Private (read and right for private usage)
 #     * Read-only (handled in __setattr__)
-#     * Global abd local measures arguments: when they change, we clear the cache of
+#     * Global and local measures arguments: when they change, we clear the cache of
 #       all the measures (handled in __setattr__)
 #     * Attributes with custom getter and setter (using @property + private name
 #       in __slots__)

--- a/src/skfolio/portfolio/_failed_portfolio.py
+++ b/src/skfolio/portfolio/_failed_portfolio.py
@@ -1,0 +1,206 @@
+"""FailedPortfolio sentinel class."""
+
+
+# Copyright (c) 2025
+# Author: Hugo Delatte <hugo.delatte@skfoliolabs.com>
+# SPDX-License-Identifier: BSD-3-Clause
+
+import numpy as np
+import numpy.typing as npt
+
+import skfolio.typing as skt
+from skfolio.portfolio._portfolio import Portfolio
+
+
+class FailedPortfolio(Portfolio):
+    r"""
+    Portfolio object returned when an optimization step fails. It acts as a sentinel
+    value that marks the failure and stores failure diagnostics (`optimization_error`,
+    `fallback_chain`).
+
+    `FailedPortfolio` preserves full API compatibility with `Portfolio` so it
+    can seamlessly pass through risk measures, aggregation, rolling computations and
+    plotting without raising. All returns, weights, composition, and derived measures
+    are NaN.
+
+    .. note::
+
+        In backtesting workflows, when an optimization estimator is configured
+        with `raise_on_failure=False`, a `FailedPortfolio` is returned on failed
+        rebalancings. This lets the process complete without raising while preserving
+        the full timeline for downstream analysis and diagnostics.
+
+    Parameters
+    ----------
+    X : array-like of shape (n_observations, n_assets)
+        Price returns of the assets.
+        If `X` is a DataFrame, the columns will be considered as assets names
+        and the indices will be considered as observations. Otherwise, we use
+        `["x0", "x1", ..., "x(n_assets - 1)"]` as asset names and
+        `[0, 1, ..., n_observations]` as observations.
+
+    optimization_error : str, optional
+        Stringified error message explaining why the optimization failed.
+        Propagated from the optimization estimator when `raise_on_failure=False`.
+        `None` means the reason is unknown or not provided.
+
+    name : str, optional
+        Name of the portfolio. The default (`None`) is to use the object id.
+
+    tag : str, optional
+        Tag given to the portfolio. Tags are used to manipulate groups of
+        Portfolios from a `Population`.
+
+    fallback_chain : list[tuple[str, str]] | None, optional
+        Sequence describing the optimization fallback attempts. Each element is
+        a pair `(estimator_repr, outcome)` where:
+
+            * `estimator_repr` is the string representation of the primary
+              estimator or a fallback (e.g. `"EqualWeighted()"`,
+              `"previous_weights"`).
+            * `outcome` is `"success"` if that step produced a valid solution,
+              otherwise the stringified error message.
+
+        For successful fits without any fallback, this is `None`. When
+        fallbacks are provided and the primary fails, the chain starts with
+        `(primary_repr, primary_error)` and is followed by one entry per
+        fallback that was attempted, ending with the first `"success"` or the
+        last error if all fail. This is set by the optimization estimator and
+        propagated to the resulting portfolio objects (including
+        `FailedPortfolio`).
+
+    Other Parameters
+    ----------------
+    previous_weights : float | dict[str, float] | array-like of shape (n_assets, ), optional
+        Accepted for API compatibility with `Portfolio` but not used by
+        `FailedPortfolio`.
+
+    transaction_costs : float | dict[str, float] | array-like of shape (n_assets, ), optional
+        Accepted for API compatibility with `Portfolio` but not used by
+        `FailedPortfolio`.
+
+    management_fees : float | dict[str, float] | array-like of shape (n_assets, ), optional
+        Accepted for API compatibility with `Portfolio` but not used by
+        `FailedPortfolio`.
+
+    risk_free_rate : float, default=0.0
+        Accepted for API compatibility with `Portfolio` but not used by
+        `FailedPortfolio`.
+
+    annualized_factor : float, default=252.0
+        Accepted for API compatibility with `Portfolio` but not used by
+        `FailedPortfolio`.
+
+    fitness_measures : list[measures], optional
+        Accepted for API compatibility with `Portfolio` but not used by
+        `FailedPortfolio`.
+
+    compounded : bool, default=False
+        Accepted for API compatibility with `Portfolio` but not used by
+        `FailedPortfolio`.
+
+    sample_weight : ndarray of shape (n_observations, ), optional
+        Accepted for API compatibility with `Portfolio` but not used by
+        `FailedPortfolio`.
+
+    min_acceptable_return : float | None, optional
+        Accepted for API compatibility with `Portfolio` but not used by
+        `FailedPortfolio`.
+
+    value_at_risk_beta : float, default=0.95
+        Accepted for API compatibility with `Portfolio` but not used by
+        `FailedPortfolio`.
+
+    entropic_risk_measure_theta : float, default=1.0
+        Accepted for API compatibility with `Portfolio` but not used by
+        `FailedPortfolio`.
+
+    entropic_risk_measure_beta : float, default=0.95
+        Accepted for API compatibility with `Portfolio` but not used by
+        `FailedPortfolio`.
+
+    cvar_beta : float, default=0.95
+        Accepted for API compatibility with `Portfolio` but not used by
+        `FailedPortfolio`.
+
+    evar_beta : float, default=0.95
+        Accepted for API compatibility with `Portfolio` but not used by
+        `FailedPortfolio`.
+
+    drawdown_at_risk_beta : float, default=0.95
+        Accepted for API compatibility with `Portfolio` but not used by
+        `FailedPortfolio`.
+
+    cdar_beta : float, default=0.95
+        Accepted for API compatibility with `Portfolio` but not used by
+        `FailedPortfolio`.
+
+    edar_beta : float, default=0.95
+        Accepted for API compatibility with `Portfolio` but not used by
+        `FailedPortfolio`.
+
+    Notes
+    -----
+    All performance, risk, and contribution measures are computed from NaN
+    returns and NaN weights in a `FailedPortfolio`. As a result, these
+    parameters do not affect the outcome: NaNs are carried over to metrics,
+    contributions, plots, and rolling computations. This class exists solely to
+    preserve API and type compatibility while signaling a failed optimization.
+    """
+
+    __slots__ = {
+        # read-write
+        "optimization_error",
+    }
+
+    def __init__(
+        self,
+        X: npt.ArrayLike,
+        name: str | None = None,
+        tag: str | None = None,
+        optimization_error: str | None = None,
+        fallback_chain: list[tuple[str, str]] | None = None,
+        previous_weights: skt.MultiInput = None,
+        transaction_costs: skt.MultiInput = None,
+        management_fees: skt.MultiInput = None,
+        risk_free_rate: float = 0,
+        annualized_factor: float = 252,
+        fitness_measures: list[skt.Measure] | None = None,
+        compounded: bool = False,
+        sample_weight: np.ndarray | None = None,
+        min_acceptable_return: float | None = None,
+        value_at_risk_beta: float = 0.95,
+        entropic_risk_measure_theta: float = 1,
+        entropic_risk_measure_beta: float = 0.95,
+        cvar_beta: float = 0.95,
+        evar_beta: float = 0.95,
+        drawdown_at_risk_beta: float = 0.95,
+        cdar_beta: float = 0.95,
+        edar_beta: float = 0.95,
+    ):
+        super().__init__(
+            X=X,
+            weights=None,
+            previous_weights=previous_weights,
+            transaction_costs=transaction_costs,
+            management_fees=management_fees,
+            risk_free_rate=risk_free_rate,
+            name=name,
+            tag=tag,
+            annualized_factor=annualized_factor,
+            fitness_measures=fitness_measures,
+            compounded=compounded,
+            sample_weight=sample_weight,
+            min_acceptable_return=min_acceptable_return,
+            value_at_risk_beta=value_at_risk_beta,
+            entropic_risk_measure_theta=entropic_risk_measure_theta,
+            entropic_risk_measure_beta=entropic_risk_measure_beta,
+            cvar_beta=cvar_beta,
+            evar_beta=evar_beta,
+            drawdown_at_risk_beta=drawdown_at_risk_beta,
+            cdar_beta=cdar_beta,
+            edar_beta=edar_beta,
+            fallback_chain=fallback_chain,
+        )
+
+        self.optimization_error = optimization_error

--- a/src/skfolio/portfolio/_failed_portfolio.py
+++ b/src/skfolio/portfolio/_failed_portfolio.py
@@ -55,11 +55,11 @@ class FailedPortfolio(Portfolio):
         Sequence describing the optimization fallback attempts. Each element is
         a pair `(estimator_repr, outcome)` where:
 
-            * `estimator_repr` is the string representation of the primary
-              estimator or a fallback (e.g. `"EqualWeighted()"`,
-              `"previous_weights"`).
-            * `outcome` is `"success"` if that step produced a valid solution,
-              otherwise the stringified error message.
+        * `estimator_repr` is the string representation of the primary
+          estimator or a fallback (e.g. `"EqualWeighted()"`,
+          `"previous_weights"`).
+        * `outcome` is `"success"` if that step produced a valid solution,
+          otherwise the stringified error message.
 
         For successful fits without any fallback, this is `None`. When
         fallbacks are provided and the primary fails, the chain starts with
@@ -69,8 +69,6 @@ class FailedPortfolio(Portfolio):
         propagated to the resulting portfolio objects (including
         `FailedPortfolio`).
 
-    Other Parameters
-    ----------------
     previous_weights : float | dict[str, float] | array-like of shape (n_assets, ), optional
         Accepted for API compatibility with `Portfolio` but not used by
         `FailedPortfolio`.

--- a/src/skfolio/portfolio/_multi_period_portfolio.py
+++ b/src/skfolio/portfolio/_multi_period_portfolio.py
@@ -570,10 +570,10 @@ class MultiPeriodPortfolio(BasePortfolio):
     def composition(self) -> pd.DataFrame:
         """DataFrame of the Portfolio composition."""
         df = pd.concat([p.composition for p in self], axis=1)
+        df.columns = deduplicate_names(df.columns)
         # Leave columns of only NaNs untouched
         mask = ~df.isna().all(axis=0)
         df.loc[:, mask] = df.loc[:, mask].fillna(0)
-        df.columns = deduplicate_names(df.columns)
         return df
 
     @property
@@ -635,10 +635,10 @@ class MultiPeriodPortfolio(BasePortfolio):
         if not to_df:
             return contributions
         df = pd.concat(contributions, axis=1)
+        df.columns = deduplicate_names(df.columns)
         # Leave columns of only NaNs untouched
         mask = ~df.isna().all(axis=0)
         df.loc[:, mask] = df.loc[:, mask].fillna(0)
-        df.columns = deduplicate_names(df.columns)
         return df
 
     def summary(self, formatted: bool = True) -> pd.Series:

--- a/src/skfolio/portfolio/_multi_period_portfolio.py
+++ b/src/skfolio/portfolio/_multi_period_portfolio.py
@@ -16,6 +16,7 @@ import plotly.graph_objects as go
 
 import skfolio.typing as skt
 from skfolio.portfolio._base import BasePortfolio
+from skfolio.portfolio._failed_portfolio import FailedPortfolio
 from skfolio.portfolio._portfolio import Portfolio
 from skfolio.utils.tools import deduplicate_names
 
@@ -551,6 +552,16 @@ class MultiPeriodPortfolio(BasePortfolio):
 
     # Classic property
     @property
+    def n_failed_portfolios(self) -> int:
+        """Number of `FailedPortfolio` in the population."""
+        return sum(isinstance(x, FailedPortfolio) for x in self)
+
+    @property
+    def n_fallback_portfolios(self) -> int:
+        """Number of Portfolios in the population that used fallback optimization."""
+        return sum(1 for x in self if getattr(x, "fallback_chain", None) is not None)
+
+    @property
     def assets(self) -> list:
         """List of assets names in each Portfolio."""
         return [p.assets for p in self]
@@ -559,9 +570,29 @@ class MultiPeriodPortfolio(BasePortfolio):
     def composition(self) -> pd.DataFrame:
         """DataFrame of the Portfolio composition."""
         df = pd.concat([p.composition for p in self], axis=1)
-        df.fillna(0, inplace=True)
+        # Leave columns of only NaNs untouched
+        mask = ~df.isna().all(axis=0)
+        df.loc[:, mask] = df.loc[:, mask].fillna(0)
         df.columns = deduplicate_names(df.columns)
         return df
+
+    @property
+    def weights_dict(self) -> dict[str, dict[str, float]]:
+        """Dictionary mapping each Portfolio name to its asset weight allocation."""
+        names = deduplicate_names([ptf.name for ptf in self.portfolios])
+        return {
+            name: ptf.weights_dict
+            for name, ptf in zip(names, self.portfolios, strict=True)
+        }
+
+    @property
+    def previous_weights_dict(self) -> dict[str, dict[str, float]]:
+        """Dictionary mapping Portfolio name to its previous asset weight allocation."""
+        names = deduplicate_names([ptf.name for ptf in self.portfolios])
+        return {
+            name: ptf.previous_weights_dict
+            for name, ptf in zip(names, self.portfolios, strict=True)
+        }
 
     @property
     def weights_per_observation(self) -> pd.DataFrame:
@@ -604,7 +635,9 @@ class MultiPeriodPortfolio(BasePortfolio):
         if not to_df:
             return contributions
         df = pd.concat(contributions, axis=1)
-        df.fillna(0, inplace=True)
+        # Leave columns of only NaNs untouched
+        mask = ~df.isna().all(axis=0)
+        df.loc[:, mask] = df.loc[:, mask].fillna(0)
         df.columns = deduplicate_names(df.columns)
         return df
 
@@ -623,13 +656,22 @@ class MultiPeriodPortfolio(BasePortfolio):
             Portfolio summary of all its measures.
         """
         df = super().summary(formatted=formatted)
-        portfolios_number = len(self)
         avg_assets_per_portfolio = np.mean([p.n_assets for p in self])
+        n_portfolios = len(self)
+        n_failed_portfolios = self.n_failed_portfolios
+        n_fallback_portfolios = self.n_fallback_portfolios
+
         if formatted:
-            portfolios_number = str(int(portfolios_number))
             avg_assets_per_portfolio = f"{avg_assets_per_portfolio:0.1f}"
-        df["Portfolios Number"] = portfolios_number
+            n_portfolios = str(int(n_portfolios))
+            n_failed_portfolios = str(n_failed_portfolios)
+            n_fallback_portfolios = str(n_fallback_portfolios)
+
         df["Avg nb of Assets per Portfolio"] = avg_assets_per_portfolio
+        df["Number of Portfolios"] = n_portfolios
+        df["Number of Failed Portfolios"] = n_failed_portfolios
+        df["Number of Fallback Portfolios"] = n_fallback_portfolios
+
         return df
 
     # Public methods

--- a/src/skfolio/portfolio/_portfolio.py
+++ b/src/skfolio/portfolio/_portfolio.py
@@ -198,20 +198,21 @@ class Portfolio(BasePortfolio):
         The default value is `0.95`.
 
     fallback_chain : list[tuple[str, str]] | None, optional
-        Sequence describing the optimization fallback attempts.
-        Each element is a pair `(estimator_repr, outcome)` where:
+        Sequence describing the optimization fallback attempts. Each element is
+        a pair `(estimator_repr, outcome)` where:
 
-            * `estimator_repr` is the string representation of the primary
-              estimator or a fallback (e.g. `"EqualWeighted()"`, `"previous_weights"`).
-            * `outcome` is `"success"` if that step produced a valid solution, otherwise
-              the stringified error message.
+        * `estimator_repr` is the string representation of the primary
+          estimator or a fallback (e.g. `"EqualWeighted()"`,
+          `"previous_weights"`).
+        * `outcome` is `"success"` if that step produced a valid solution,
+          otherwise the stringified error message.
 
         For successful fits without any fallback, this is `None`. When
         fallbacks are provided and the primary fails, the chain starts with
         `(primary_repr, primary_error)` and is followed by one entry per
         fallback that was attempted, ending with the first `"success"` or the
         last error if all fail. This is set by the optimization estimator and
-        propagated to the resulting `Portfolio`.
+        propagated to the resulting portfolio.
 
     Attributes
     ----------

--- a/src/skfolio/portfolio/_portfolio.py
+++ b/src/skfolio/portfolio/_portfolio.py
@@ -16,6 +16,7 @@ import numpy.typing as npt
 import pandas as pd
 
 import skfolio.typing as skt
+from skfolio._constants import _ParamKey
 from skfolio.measures import RiskMeasure, effective_number_assets
 from skfolio.portfolio._base import _ZERO_THRESHOLD, BasePortfolio
 from skfolio.utils.tools import (
@@ -422,23 +423,22 @@ class Portfolio(BasePortfolio):
             "X",
             "assets",
             "weights",
-            "previous_weights",
-            "transaction_costs",
-            "management_fees",
+            _ParamKey.PREVIOUS_WEIGHTS.value,
+            _ParamKey.TRANSACTION_COSTS.value,
+            _ParamKey.MANAGEMENT_FEES.value,
             "n_assets",
             "total_cost",
             "total_fee",
         }
     )
 
-    # ruff: noqa: RUF023
     __slots__ = {
         # read-only
         "X",
         "weights",
-        "previous_weights",
-        "transaction_costs",
-        "management_fees",
+        _ParamKey.PREVIOUS_WEIGHTS.value,
+        _ParamKey.TRANSACTION_COSTS.value,
+        _ParamKey.MANAGEMENT_FEES.value,
         "assets",
         "n_assets",
         "total_cost",
@@ -511,7 +511,7 @@ class Portfolio(BasePortfolio):
                 fill_value=0,
                 dim=1,
                 assets_names=assets,
-                name="previous_weights",
+                name=_ParamKey.PREVIOUS_WEIGHTS.value,
             )
 
         if transaction_costs is None:
@@ -523,7 +523,7 @@ class Portfolio(BasePortfolio):
                 fill_value=0,
                 dim=1,
                 assets_names=assets,
-                name="transaction_costs",
+                name=_ParamKey.TRANSACTION_COSTS.value,
             )
 
         if management_fees is None:
@@ -535,7 +535,7 @@ class Portfolio(BasePortfolio):
                 fill_value=0,
                 dim=1,
                 assets_names=assets,
-                name="management_fees",
+                name=_ParamKey.MANAGEMENT_FEES.value,
             )
 
         # Default observations and assets if X is not a DataFrame

--- a/src/skfolio/typing.py
+++ b/src/skfolio/typing.py
@@ -4,7 +4,10 @@
 # Author: Hugo Delatte <delatte.hugo@gmail.com>
 # SPDX-License-Identifier: BSD-3-Clause
 
+from __future__ import annotations
+
 from collections.abc import Callable
+from typing import TYPE_CHECKING, Literal, TypeAlias, Union
 
 import cvxpy as cp
 import numpy as np
@@ -13,10 +16,14 @@ import plotly.graph_objects as go
 
 from skfolio.measures import ExtraRiskMeasure, PerfMeasure, RatioMeasure, RiskMeasure
 
+if TYPE_CHECKING:
+    from skfolio.optimization._base import BaseOptimization
+
 __all__ = [
     "CvxMeasure",
     "ExpressionFunction",
     "Factor",
+    "Fallback",
     "Groups",
     "Inequality",
     "LinearConstraints",
@@ -45,6 +52,12 @@ RiskResult = tuple[
 ]
 ExpressionFunction = Callable[[cp.Variable, any], cp.Expression]
 Figure = go.Figure
+Fallback: TypeAlias = Union[
+    "BaseOptimization",
+    list[Union["BaseOptimization", Literal["previous_weights"]]],
+    Literal["previous_weights"],
+    None,
+]
 
 # Population
 Names = str | list[str]

--- a/src/skfolio/utils/stats.py
+++ b/src/skfolio/utils/stats.py
@@ -150,8 +150,8 @@ def rand_weights_dirichlet(n: int) -> np.array:
     return np.random.dirichlet(np.ones(n))
 
 
-def rand_weights(n: int, zeros: int = 0) -> np.array:
-    """Produces n random weights that sum to one from an uniform distribution
+def rand_weights(n: int, zeros: int = 0, seed: int | None = None) -> np.ndarray:
+    """Produces n random weights that sum to one from a uniform distribution
     (non-uniform distribution over a simplex).
 
     Parameters
@@ -162,16 +162,21 @@ def rand_weights(n: int, zeros: int = 0) -> np.array:
     zeros : int, default=0
         The number of weights to randomly set to zeros.
 
+    seed : int or None, default=None
+        Seed for reproducibility. If None, use an unseeded generator.
+
     Returns
     -------
     weights : ndarray of shape (n, )
         The vector of weights.
     """
-    k = np.random.rand(n)
+    rng = np.random.default_rng(seed)
+
+    k = rng.random(n)
     if zeros > 0:
-        zeros_idx = np.random.choice(n, zeros, replace=False)
+        zeros_idx = rng.choice(n, zeros, replace=False)
         k[zeros_idx] = 0
-    return k / sum(k)
+    return k / k.sum()
 
 
 def is_cholesky_dec(x: np.ndarray) -> bool:

--- a/src/skfolio/utils/tools.py
+++ b/src/skfolio/utils/tools.py
@@ -549,6 +549,8 @@ def optimal_rounding_decimals(x: float) -> int:
     n : int
         Rounding decimal number.
     """
+    if np.isclose(x, 0.0):
+        return 2
     return min(6, max(int(-np.log10(abs(x))) + 2, 2))
 
 

--- a/tests/test_model_selection/test_validation.py
+++ b/tests/test_model_selection/test_validation.py
@@ -4,18 +4,27 @@ import numpy as np
 import sklearn.model_selection as sks
 from sklearn import config_context
 from sklearn.model_selection import KFold
+from sklearn.pipeline import Pipeline
 
 from skfolio import MultiPeriodPortfolio, Population
 from skfolio.model_selection import (
     CombinatorialPurgedCV,
+    MultipleRandomizedCV,
     WalkForward,
     cross_val_predict,
 )
 from skfolio.moments import (
     ImpliedCovariance,
 )
-from skfolio.optimization import InverseVolatility, MeanRisk
+from skfolio.optimization import InverseVolatility, MeanRisk, ObjectiveFunction
+from skfolio.pre_selection import SelectKExtremes
 from skfolio.prior import EmpiricalPrior
+
+
+def assert_weights_dict_subset_equal(d1: dict, d2: dict, tol: float = 1e-15) -> None:
+    """True iff for every key k in d2 d1.get(k, 0.0) matches d2[k] within tol."""
+    for k, b in d2.items():
+        assert abs(d1.get(k, 0.0) - b) < tol
 
 
 def test_validation(X):
@@ -74,3 +83,182 @@ def test_meta_data_routing_cross_validation(X, implied_vol):
         cv = KFold()
 
         _ = cross_val_predict(model, X, params={"implied_vol": implied_vol}, cv=cv)
+
+
+def test_optim_with_previous_weights_walk_forward(X):
+    cv = WalkForward(test_size=300, train_size=400)
+
+    ref = MeanRisk(objective_function=ObjectiveFunction.MAXIMIZE_UTILITY)
+    assert ref.needs_previous_weights is False
+    pred_ref = cross_val_predict(ref, X, cv=cv)
+
+    model = MeanRisk(
+        objective_function=ObjectiveFunction.MAXIMIZE_UTILITY, transaction_costs=0.001
+    )
+    assert model.needs_previous_weights is True
+    pred = cross_val_predict(model, X, cv=cv)
+
+    assert abs((pred_ref.composition - pred.composition)["MeanRisk_5"].sum()) > 0.2
+
+    assert np.all(pred[0].previous_weights == 0)
+
+    for i in range(1, len(pred)):
+        np.testing.assert_almost_equal(pred[i - 1].weights, pred[i].previous_weights)
+        assert_weights_dict_subset_equal(
+            pred[i - 1].weights_dict, pred[i].previous_weights_dict
+        )
+
+
+def test_pipeline_with_previous_weights_walk_forward(X):
+    cv = WalkForward(test_size=300, train_size=400)
+
+    pipe_ref = Pipeline(
+        [
+            ("pre_selection", SelectKExtremes(k=10)),
+            ("optim", MeanRisk(ObjectiveFunction.MAXIMIZE_UTILITY)),
+        ]
+    )
+
+    pipe = Pipeline(
+        [
+            ("pre_selection", SelectKExtremes(k=10)),
+            (
+                "optim",
+                MeanRisk(ObjectiveFunction.MAXIMIZE_UTILITY, transaction_costs=0.01),
+            ),
+        ]
+    )
+
+    with config_context(transform_output="pandas"):
+        pred_ref = cross_val_predict(pipe_ref, X, cv=cv)
+        pred = cross_val_predict(pipe, X, cv=cv)
+
+    assert abs((pred_ref.composition - pred.composition)["MeanRisk_5"].sum()) > 0.2
+
+    assert np.all(pred[0].previous_weights == 0)
+
+    for i in range(1, len(pred)):
+        assert not np.allclose(pred[i].previous_weights, 0)
+        assert_weights_dict_subset_equal(
+            pred[i - 1].weights_dict, pred[i].previous_weights_dict
+        )
+
+
+def test_pipeline_with_previous_weights_walk_forward_initial_pre_w(X):
+    cv = WalkForward(test_size=300, train_size=400)
+    previous_weights = {name: 0.2 for name in X.columns}
+
+    pipe = Pipeline(
+        [
+            ("pre_selection", SelectKExtremes(k=10)),
+            (
+                "optim",
+                MeanRisk(
+                    ObjectiveFunction.MAXIMIZE_UTILITY,
+                    transaction_costs=0.01,
+                    previous_weights=previous_weights,
+                ),
+            ),
+        ]
+    )
+
+    with config_context(transform_output="pandas"):
+        pred = cross_val_predict(pipe, X, cv=cv)
+
+    prev_w = pred[0].previous_weights
+    assert np.all(prev_w == 0.2)
+    for i in range(1, len(pred)):
+        assert not np.allclose(pred[i].previous_weights, 0)
+        assert_weights_dict_subset_equal(
+            pred[i - 1].weights_dict, pred[i].previous_weights_dict
+        )
+
+
+def test_pipeline_with_previous_weights_multiple_randomized_cv(X):
+    cv = MultipleRandomizedCV(
+        walk_forward=WalkForward(test_size=300, train_size=400),
+        n_subsamples=5,
+        asset_subset_size=5,
+        window_size=1200,
+        random_state=0,
+    )
+
+    pipe_ref = Pipeline(
+        [
+            ("pre_selection", SelectKExtremes(k=10)),
+            ("optim", MeanRisk(ObjectiveFunction.MAXIMIZE_UTILITY)),
+        ]
+    )
+
+    pipe = Pipeline(
+        [
+            ("pre_selection", SelectKExtremes(k=10)),
+            (
+                "optim",
+                MeanRisk(ObjectiveFunction.MAXIMIZE_UTILITY, transaction_costs=1e-20),
+            ),
+        ]
+    )
+
+    pipe_tc = Pipeline(
+        [
+            ("pre_selection", SelectKExtremes(k=10)),
+            (
+                "optim",
+                MeanRisk(
+                    ObjectiveFunction.MAXIMIZE_UTILITY,
+                    transaction_costs=0.001,
+                    previous_weights={name: 0.1 for name in X.columns},
+                ),
+            ),
+        ]
+    )
+
+    with config_context(transform_output="pandas"):
+        pred_ref = cross_val_predict(pipe_ref, X, cv=cv)
+        pred = cross_val_predict(pipe, X, cv=cv)
+        pred_tc = cross_val_predict(pipe_tc, X, cv=cv)
+
+    assert abs(pred_ref.composition() - pred.composition()).sum().sum() < 1e-3
+    assert abs(pred_ref.composition() - pred_tc.composition()).sum().sum() > 7
+
+    for mpp in pred_tc:
+        assert np.all(mpp[0].previous_weights == 0.1)
+        for i in range(1, len(mpp)):
+            assert not np.allclose(mpp[i].previous_weights, 0.1)
+            assert_weights_dict_subset_equal(
+                mpp[i - 1].weights_dict, mpp[i].previous_weights_dict
+            )
+
+
+def test_fallback_previous_weights_propagation(X):
+    cv = WalkForward(test_size=300, train_size=400)
+    ref = MeanRisk(
+        min_weights=1,
+        fallback=MeanRisk(
+            objective_function=ObjectiveFunction.MAXIMIZE_UTILITY,
+        ),
+    )
+    assert ref.needs_previous_weights is False
+
+    model = MeanRisk(
+        min_weights=1,
+        fallback=MeanRisk(
+            objective_function=ObjectiveFunction.MAXIMIZE_UTILITY,
+            transaction_costs=0.001,
+        ),
+    )
+    assert model.needs_previous_weights is True
+
+    pred_ref = cross_val_predict(ref, X, cv=cv)
+    pred = cross_val_predict(model, X, cv=cv)
+
+    assert abs((pred_ref.composition - pred.composition)["MeanRisk_5"]).sum() > 0.5
+
+    assert np.all(pred[0].previous_weights == 0)
+    for i in range(1, len(pred)):
+        assert not np.allclose(pred[i].previous_weights, 0)
+        np.testing.assert_almost_equal(pred[i - 1].weights, pred[i].previous_weights)
+        assert_weights_dict_subset_equal(
+            pred[i - 1].weights_dict, pred[i].previous_weights_dict
+        )

--- a/tests/test_optimization/test_fallback.py
+++ b/tests/test_optimization/test_fallback.py
@@ -1,0 +1,583 @@
+import numpy as np
+import pandas as pd
+import pytest
+import sklearn as sk
+import sklearn.model_selection as sks
+import sklearn.utils.validation as skv
+from sklearn import config_context
+from sklearn.pipeline import Pipeline
+
+from skfolio.model_selection import cross_val_predict
+from skfolio.optimization import (
+    BaseOptimization,
+    EqualWeighted,
+    HierarchicalRiskParity,
+    MeanRisk,
+    ObjectiveFunction,
+)
+from skfolio.portfolio import FailedPortfolio, Portfolio
+from skfolio.pre_selection import (
+    SelectKExtremes,
+)
+from skfolio.prior import FactorModel
+
+
+def assert_weights_dict_subset_equal(d1: dict, d2: dict, tol: float = 1e-15) -> None:
+    """True iff for every key k in d2 d1.get(k, 0.0) matches d2[k] within tol."""
+    for k, b in d2.items():
+        assert abs(d1.get(k, 0.0) - b) < tol
+
+
+class CustomOptimization(BaseOptimization):
+    """Simple custom optimizer forcing fit failure to test fallback"""
+
+    def __init__(
+        self,
+        fail: bool = False,
+        portfolio_params: dict | None = None,
+        fallback=None,
+        previous_weights: np.ndarray | None = None,
+        raise_on_failure: bool = True,
+    ):
+        super().__init__(
+            portfolio_params=portfolio_params,
+            fallback=fallback,
+            raise_on_failure=raise_on_failure,
+            previous_weights=previous_weights,
+        )
+        self.fail = fail
+
+    def fit(self, X, y=None):
+        X = skv.validate_data(self, X)
+        if self.fail:
+            raise RuntimeError("CustomOptimization forced failure")
+        n_assets = X.shape[1]
+        self.weights_ = np.arange(n_assets, dtype=float)
+        self.weights_ /= np.sum(self.weights_)
+        return self
+
+
+class CustomOptimizationWithoutFallback(BaseOptimization):
+    """Simple custom optimizer without 'fallback' in __init__ to test
+    backward-compatibility of the fallback mechanism.
+    """
+
+    def __init__(self, portfolio_params: dict | None = None):
+        super().__init__(portfolio_params=portfolio_params)
+
+    def fit(self, X, y=None):
+        X = skv.validate_data(self, X)
+        n_assets = X.shape[1]
+        self.weights_ = np.arange(1, 1 + n_assets, dtype=float)
+        self.weights_ /= np.sum(self.weights_)
+        return self
+
+
+def test_custom_optimization_no_fallback_param_in_init_still_works(X):
+    model = CustomOptimizationWithoutFallback()
+    model.fit(X)
+    assert hasattr(model, "weights_")
+    assert np.isclose(model.weights_.sum(), 1.0)
+    assert model.fallback_ is None
+    assert model.fallback_chain_ is None
+    assert model.error_ is None
+    assert model.n_features_in_ == 20
+    np.testing.assert_array_equal(model.feature_names_in_, X.columns)
+
+    ptf = model.predict(X)
+    assert isinstance(ptf, Portfolio) and not isinstance(ptf, FailedPortfolio)
+    assert ptf.fallback_chain == model.fallback_chain_
+
+
+def test_fallback(X):
+    # Primary estimator fails; first fallback also fails; second fallback succeeds
+    model = CustomOptimization(fail=True, fallback=EqualWeighted())
+    model.fit(X)
+    assert hasattr(model, "weights_")
+    np.testing.assert_array_equal(model.weights_, EqualWeighted().fit(X).weights_)
+    assert isinstance(model.fallback_, EqualWeighted)
+    assert model.fallback_chain_ == [
+        (
+            "CustomOptimization(fail=True, fallback=EqualWeighted())",
+            "CustomOptimization forced failure",
+        ),
+        ("EqualWeighted()", "success"),
+    ]
+    assert model.error_ is None
+    assert model.n_features_in_ == 20
+    np.testing.assert_array_equal(model.feature_names_in_, X.columns)
+    ptf = model.predict(X)
+    assert isinstance(ptf, Portfolio) and not isinstance(ptf, FailedPortfolio)
+    assert ptf.fallback_chain == model.fallback_chain_
+
+
+def test_fallback_with_clone(X):
+    # Primary estimator fails; first fallback also fails; second fallback succeeds
+    model = CustomOptimization(fail=True, fallback=EqualWeighted())
+    model = sk.clone(model)
+    model.fit(X)
+    assert hasattr(model, "weights_")
+    np.testing.assert_array_equal(model.weights_, EqualWeighted().fit(X).weights_)
+    assert isinstance(model.fallback_, EqualWeighted)
+    assert model.fallback_chain_ == [
+        (
+            "CustomOptimization(fail=True, fallback=EqualWeighted())",
+            "CustomOptimization forced failure",
+        ),
+        ("EqualWeighted()", "success"),
+    ]
+    assert model.error_ is None
+    assert model.n_features_in_ == 20
+    np.testing.assert_array_equal(model.feature_names_in_, X.columns)
+    ptf = model.predict(X)
+    assert isinstance(ptf, Portfolio) and not isinstance(ptf, FailedPortfolio)
+    assert ptf.fallback_chain == model.fallback_chain_
+
+
+def test_fallback_list_first_fails_then_succeeds(X):
+    # Primary estimator fails; first fallback also fails; second fallback succeeds
+    model = CustomOptimization(
+        fail=True, fallback=[CustomOptimization(fail=True), EqualWeighted()]
+    )
+
+    model.fit(X)
+    assert hasattr(model, "weights_")
+    np.testing.assert_array_equal(model.weights_, EqualWeighted().fit(X).weights_)
+    assert isinstance(model.fallback_, EqualWeighted)
+    assert model.fallback_chain_ == [
+        (
+            "CustomOptimization(fail=True,\n                   fallback=[CustomOptimization(fail=True), EqualWeighted()])",
+            "CustomOptimization forced failure",
+        ),
+        ("CustomOptimization(fail=True)", "CustomOptimization forced failure"),
+        ("EqualWeighted()", "success"),
+    ]
+    assert model.error_ is None
+    assert model.n_features_in_ == 20
+    np.testing.assert_array_equal(model.feature_names_in_, X.columns)
+
+    ptf = model.predict(X)
+    assert isinstance(ptf, Portfolio) and not isinstance(ptf, FailedPortfolio)
+    assert ptf.fallback_chain == model.fallback_chain_
+
+
+def test_fallback_chain_first_fails_then_succeeds(X):
+    # Primary estimator fails; first fallback also fails; second fallback succeeds
+    model = CustomOptimization(fail=True)
+    model.fallback = CustomOptimization(fail=True)
+    model.fallback.fallback = EqualWeighted()
+
+    model.fit(X)
+    assert hasattr(model, "weights_")
+    np.testing.assert_array_equal(model.weights_, EqualWeighted().fit(X).weights_)
+    assert isinstance(model.fallback_, CustomOptimization)
+    assert model.fallback_chain_ == [
+        (
+            "CustomOptimization(fail=True,\n                   fallback=CustomOptimization(fail=True,\n                                               fallback=EqualWeighted()))",
+            "CustomOptimization forced failure",
+        ),
+        ("CustomOptimization(fail=True, fallback=EqualWeighted())", "success"),
+    ]
+    assert model.error_ is None
+    assert model.n_features_in_ == 20
+    np.testing.assert_array_equal(model.feature_names_in_, X.columns)
+    ptf = model.predict(X)
+    assert isinstance(ptf, Portfolio) and not isinstance(ptf, FailedPortfolio)
+    assert ptf.fallback_chain == model.fallback_chain_
+
+
+def test_predict_after_fallback_returns_portfolio(X):
+    model = CustomOptimization(fail=True, fallback=EqualWeighted())
+    ptf = model.fit(X).predict(X)
+    assert isinstance(ptf, Portfolio) and not isinstance(ptf, FailedPortfolio)
+    assert model.fallback_chain_ == [
+        (
+            "CustomOptimization(fail=True, fallback=EqualWeighted())",
+            "CustomOptimization forced failure",
+        ),
+        ("EqualWeighted()", "success"),
+    ]
+    assert not hasattr(ptf, "optimization_error")
+    assert ptf.weights is not None and np.isclose(ptf.weights.sum(), 1.0)
+
+
+def test_fallback_factor_model(X, y):
+    model = CustomOptimization(
+        fail=True, fallback=MeanRisk(prior_estimator=FactorModel())
+    )
+    model.fit(X, y)
+    assert hasattr(model, "weights_")
+    assert isinstance(model.fallback_, MeanRisk)
+    assert model.fallback_chain_ == [
+        (
+            "CustomOptimization(fail=True, fallback=MeanRisk(prior_estimator=FactorModel()))",
+            "CustomOptimization forced failure",
+        ),
+        ("MeanRisk(prior_estimator=FactorModel())", "success"),
+    ]
+    assert model.error_ is None
+    assert model.n_features_in_ == 20
+    np.testing.assert_array_equal(model.feature_names_in_, X.columns)
+    ptf = model.predict(X)
+    assert isinstance(ptf, Portfolio) and not isinstance(ptf, FailedPortfolio)
+    assert ptf.fallback_chain == model.fallback_chain_
+
+
+def test_cross_val_predict_with_fallback(X):
+    model = CustomOptimization(fail=True, fallback=EqualWeighted())
+    mpp = cross_val_predict(model, X, cv=sks.KFold(n_splits=3))
+    assert mpp.n_failed_portfolios == 0
+    assert mpp.n_fallback_portfolios == 3
+    for ptf in mpp:
+        assert isinstance(ptf, Portfolio) and not isinstance(ptf, FailedPortfolio)
+        assert ptf.fallback_chain == [
+            (
+                "CustomOptimization(fail=True, fallback=EqualWeighted())",
+                "CustomOptimization forced failure",
+            ),
+            ("EqualWeighted()", "success"),
+        ]
+        assert not hasattr(ptf, "optimization_error")
+        assert ptf.weights is not None and np.isclose(ptf.weights.sum(), 1.0)
+
+    assert np.asarray(mpp).shape[0] == X.shape[0]
+    assert not np.isnan(np.asarray(mpp)).any()
+    assert isinstance(mpp.summary(), pd.Series)
+    summary = mpp.summary()
+    assert summary.loc["Number of Portfolios"] == "3"
+    assert summary.loc["Number of Failed Portfolios"] == "0"
+    assert summary.loc["Number of Fallback Portfolios"] == "3"
+    summary = mpp.summary(formatted=False)
+    assert summary.loc["Number of Portfolios"] == 3
+    assert summary.loc["Number of Failed Portfolios"] == 0
+    assert summary.loc["Number of Fallback Portfolios"] == 3
+
+
+def test_failed_portfolio_when_raise_off(X):
+    model = CustomOptimization(fail=True, raise_on_failure=False)
+    with pytest.warns(UserWarning):
+        model.fit(X)
+    assert hasattr(model, "weights_")
+    assert model.weights_ is None
+    assert model.fallback_ is None
+    assert model.fallback_chain_ is None
+    assert model.error_ == "CustomOptimization forced failure"
+    assert model.n_features_in_ == 20
+    np.testing.assert_array_equal(model.feature_names_in_, X.columns)
+    ptf = model.predict(X)
+    assert isinstance(ptf, FailedPortfolio)
+    assert ptf.fallback_chain is None
+
+
+def test_failed_portfolio_when_raise_off_with_fallback(X):
+    model = CustomOptimization(
+        fail=True, fallback=CustomOptimization(fail=True), raise_on_failure=False
+    )
+    with pytest.warns(UserWarning):
+        model.fit(X)
+    assert hasattr(model, "weights_")
+    assert model.weights_ is None
+    assert model.fallback_chain_ == [
+        (
+            "CustomOptimization(fail=True, fallback=CustomOptimization(fail=True),\n                   raise_on_failure=False)",
+            "CustomOptimization forced failure",
+        ),
+        ("CustomOptimization(fail=True)", "CustomOptimization forced failure"),
+    ]
+    assert model.error_ == "CustomOptimization forced failure"
+    assert model.n_features_in_ == 20
+    np.testing.assert_array_equal(model.feature_names_in_, X.columns)
+    ptf = model.predict(X)
+    assert isinstance(ptf, FailedPortfolio)
+    assert ptf.fallback_chain == model.fallback_chain_
+
+
+def test_fallback_with_raise_off(X):
+    model = CustomOptimization(
+        fail=True, fallback=CustomOptimization(fail=False), raise_on_failure=False
+    )
+    model.fit(X)
+    assert hasattr(model, "weights_")
+    assert model.weights_ is not None
+    assert model.fallback_chain_ == [
+        (
+            "CustomOptimization(fail=True, fallback=CustomOptimization(),\n                   raise_on_failure=False)",
+            "CustomOptimization forced failure",
+        ),
+        ("CustomOptimization()", "success"),
+    ]
+    assert model.error_ is None
+    assert model.n_features_in_ == 20
+    np.testing.assert_array_equal(model.feature_names_in_, X.columns)
+    ptf = model.predict(X)
+    assert ptf.fallback_chain == model.fallback_chain_
+
+
+def test_cross_val_predict_failed_portfolio_when_raise_off(X):
+    model = CustomOptimization(fail=True, raise_on_failure=False)
+    with pytest.warns(UserWarning):
+        mpp = cross_val_predict(model, X, cv=sks.KFold(n_splits=3))
+    for ptf in mpp:
+        assert isinstance(ptf, FailedPortfolio)
+        assert ptf.optimization_error == "CustomOptimization forced failure"
+        assert ptf.fallback_chain is None
+
+    # All folds fail -> returns should be NaN
+    arr = np.asarray(mpp)
+    assert arr.shape[0] == X.shape[0]
+    assert np.all(np.isnan(arr))
+
+
+def test_fallback_previous_weights_array(X):
+    n_assets = X.shape[1]
+    prev = np.arange(1, n_assets + 1, dtype=float)
+    prev /= prev.sum()
+    model = CustomOptimization(
+        fail=True, fallback="previous_weights", previous_weights=prev
+    )
+    model.fit(X)
+    np.testing.assert_allclose(model.weights_, prev)
+    assert model.fallback_ == "previous_weights"
+    assert model.error_ is None
+    ptf = model.predict(X)
+    assert isinstance(ptf, Portfolio) and not isinstance(ptf, FailedPortfolio)
+    assert ptf.fallback_chain == model.fallback_chain_
+
+
+def test_fallback_previous_weights_dict(X):
+    prev = {"AAPL": 0.4, "AMD": 0.2, "UNH": 0.4}
+    model = CustomOptimization(
+        fail=True, previous_weights=prev, fallback="previous_weights"
+    )
+    model.fit(X)
+    np.testing.assert_allclose(
+        model.weights_,
+        [
+            0.4,
+            0.2,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.4,
+            0.0,
+            0.0,
+        ],
+    )
+    assert model.fallback_ == "previous_weights"
+    assert model.fallback_chain_ == [
+        (
+            "CustomOptimization(fail=True, fallback='previous_weights',\n                   previous_weights={'AAPL': 0.4, 'AMD': 0.2, 'UNH': 0.4})",
+            "CustomOptimization forced failure",
+        ),
+        ("previous_weights", "success"),
+    ]
+    assert model.error_ is None
+    ptf = model.predict(X)
+    assert isinstance(ptf, Portfolio) and not isinstance(ptf, FailedPortfolio)
+    assert ptf.fallback_chain == model.fallback_chain_
+
+
+@pytest.mark.filterwarnings("ignore:Solution may be inaccurate")
+def test_hyperparam_tuning_on_fallback_param(X):
+    # Force primary to fail; tune which fallback to use
+    model = MeanRisk(
+        objective_function=ObjectiveFunction.MAXIMIZE_RATIO, min_weights=1.0
+    )
+    param_grid = {
+        "fallback": [EqualWeighted(), HierarchicalRiskParity()],
+    }
+    gs = sks.GridSearchCV(estimator=model, param_grid=param_grid, cv=3)
+    gs.fit(X)
+
+    best_model = gs.best_estimator_
+    assert hasattr(best_model, "weights_")
+    assert isinstance(best_model.fallback_, HierarchicalRiskParity)
+    assert best_model.fallback_chain_ == [
+        (
+            "MeanRisk(fallback=HierarchicalRiskParity(), min_weights=1.0,\n         objective_function=MAXIMIZE_RATIO)",
+            "Solver 'CLARABEL' failed. Try another solver, or solve with solver_params=dict(verbose=True) for more information",
+        ),
+        ("HierarchicalRiskParity()", "success"),
+    ]
+    assert best_model.error_ is None
+    ptf = best_model.predict(X)
+    assert isinstance(ptf, Portfolio) and not isinstance(ptf, FailedPortfolio)
+    assert ptf.fallback_chain == best_model.fallback_chain_
+
+
+def test_pipeline_on_fallback(X):
+    model = CustomOptimization(fail=True, fallback=EqualWeighted())
+    pipe = Pipeline([("pre_selection", SelectKExtremes(k=10)), ("optim", model)])
+
+    with config_context(transform_output="pandas"):
+        pipe.fit(X)
+
+    om = pipe.named_steps["optim"]
+    assert om.weights_ is not None
+    assert isinstance(om.fallback_, EqualWeighted)
+    assert om.fallback_chain_ == [
+        (
+            "CustomOptimization(fail=True, fallback=EqualWeighted())",
+            "CustomOptimization forced failure",
+        ),
+        ("EqualWeighted()", "success"),
+    ]
+    assert om.error_ is None
+
+    ptf = pipe.predict(X)
+    assert isinstance(ptf, Portfolio) and not isinstance(ptf, FailedPortfolio)
+    assert ptf.fallback_chain == om.fallback_chain_
+
+
+def test_pipeline_on_fallback_raise_off(X):
+    model = CustomOptimization(
+        fail=True, fallback=CustomOptimization(fail=True), raise_on_failure=False
+    )
+    pipe = Pipeline([("pre_selection", SelectKExtremes(k=10)), ("optim", model)])
+
+    with pytest.warns(UserWarning):
+        with config_context(transform_output="pandas"):
+            pipe.fit(X)
+
+    om = pipe.named_steps["optim"]
+    assert om.weights_ is None
+    assert om.fallback_ is None
+    assert om.fallback_chain_ == [
+        (
+            "CustomOptimization(fail=True, fallback=CustomOptimization(fail=True),\n                   raise_on_failure=False)",
+            "CustomOptimization forced failure",
+        ),
+        ("CustomOptimization(fail=True)", "CustomOptimization forced failure"),
+    ]
+    assert om.error_ == "CustomOptimization forced failure"
+
+    ptf = pipe.predict(X)
+    assert isinstance(ptf, FailedPortfolio)
+    assert ptf.fallback_chain == om.fallback_chain_
+    assert ptf.optimization_error == om.error_
+
+
+def test_previous_weights_propagation(X):
+    prev = {"AAPL": 0.4, "AMD": 0.2, "UNH": 0.4}
+    model = CustomOptimization(
+        fail=True, previous_weights=prev, fallback=CustomOptimization(fail=False)
+    )
+    model.fit(X)
+    assert model.fallback_.previous_weights == prev
+    ptf = model.predict(X)
+    assert_weights_dict_subset_equal(ptf.previous_weights_dict, prev)
+
+    model = CustomOptimization(
+        fail=True,
+        previous_weights=prev,
+        fallback=CustomOptimization(fail=True, fallback="previous_weights"),
+    )
+    model.fit(X)
+    assert model.fallback_.previous_weights == prev
+    np.testing.assert_array_equal(
+        model.weights_,
+        [
+            0.4,
+            0.2,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.4,
+            0.0,
+            0.0,
+        ],
+    )
+    ptf = model.predict(X)
+    assert_weights_dict_subset_equal(ptf.previous_weights_dict, prev)
+
+    model = CustomOptimization(
+        fail=True,
+        previous_weights=prev,
+        fallback=[CustomOptimization(fail=True), "previous_weights"],
+    )
+    model.fit(X)
+    np.testing.assert_array_equal(
+        model.weights_,
+        [
+            0.4,
+            0.2,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.4,
+            0.0,
+            0.0,
+        ],
+    )
+    ptf = model.predict(X)
+    assert_weights_dict_subset_equal(ptf.previous_weights_dict, prev)
+
+
+def test_fallback_needs_previous_weights(X):
+    model = MeanRisk(
+        fallback=MeanRisk(
+            transaction_costs=0.001,
+        ),
+    )
+    assert model.needs_previous_weights is True
+
+    model = MeanRisk(
+        fallback=MeanRisk(),
+    )
+    assert model.needs_previous_weights is False
+
+    model = MeanRisk(
+        fallback="previous_weights",
+    )
+    assert model.needs_previous_weights is True
+
+    model = MeanRisk(
+        fallback=[MeanRisk(), "previous_weights"],
+    )
+    assert model.needs_previous_weights is True
+
+    model = MeanRisk(
+        fallback=[MeanRisk(), MeanRisk()],
+    )
+    assert model.needs_previous_weights is False
+
+    model = MeanRisk(
+        fallback=[MeanRisk(), MeanRisk(max_turnover=0.5)],
+    )
+    assert model.needs_previous_weights is True

--- a/tests/test_portfolio/test_failed_portfolio.py
+++ b/tests/test_portfolio/test_failed_portfolio.py
@@ -1,0 +1,293 @@
+import pickle
+import timeit
+import tracemalloc
+from copy import copy
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import skfolio.measures as mt
+from skfolio import (
+    ExtraRiskMeasure,
+    FailedPortfolio,
+    MultiPeriodPortfolio,
+    PerfMeasure,
+    Portfolio,
+    RatioMeasure,
+    RiskMeasure,
+)
+from skfolio.portfolio._base import _MEASURES
+from skfolio.utils.stats import rand_weights
+from skfolio.utils.tools import args_names
+
+
+@pytest.fixture(
+    scope="module",
+    params=list(PerfMeasure)
+    + list(RiskMeasure)
+    + list(RiskMeasure)
+    + list(ExtraRiskMeasure),
+)
+def measure(request):
+    return request.param
+
+
+@pytest.fixture
+def portfolio(X: pd.DataFrame) -> FailedPortfolio:
+    portfolio = FailedPortfolio(X=X)
+    return portfolio
+
+
+def test_pickle(portfolio):
+    portfolio.sharpe_ratio = 5
+    pickled = pickle.dumps(portfolio)
+    unpickled = pickle.loads(pickled)
+    assert unpickled.name == portfolio.name
+    assert portfolio.sharpe_ratio != unpickled.sharpe_ratio
+
+    mmp = MultiPeriodPortfolio(portfolios=[portfolio, portfolio])
+    pickled = pickle.dumps(mmp)
+    unpickled = pickle.loads(pickled)
+    assert unpickled.portfolios[0].sharpe_ratio
+
+
+def test_concatenate(X):
+    portfolios = [FailedPortfolio(X=X), FailedPortfolio(X=X)]
+    c = np.concatenate(portfolios)
+    assert c.shape == (X.shape[0] * 2,)
+
+
+def _estimate_portfolio_memory(X, n: int) -> float:
+    tracemalloc.start()
+    tracemalloc.clear_traces()
+    start = tracemalloc.get_traced_memory()
+    for _ in range(n):
+        portfolio = FailedPortfolio(X=X)
+        _ = portfolio.returns
+        _ = portfolio.standard_deviation
+        _ = portfolio.fitness
+        _ = portfolio.mean_absolute_deviation_ratio
+    end = tracemalloc.get_traced_memory()
+    tracemalloc.clear_traces()
+    return end[0] - start[0]
+
+
+def test_garbage_collection(X):
+    m1 = _estimate_portfolio_memory(X, n=1)
+    m10 = _estimate_portfolio_memory(X, n=10)
+    m100 = _estimate_portfolio_memory(X, n=100)
+    m1000 = _estimate_portfolio_memory(X, n=1000)
+
+    assert m10 < 2 * m1
+    assert m100 < 2 * m1
+    assert m1000 < 2 * m1
+
+
+def test_portfolio_methods(X, portfolio):
+    assert portfolio.n_observations == X.shape[0]
+    assert portfolio.n_assets == X.shape[1]
+    assert portfolio.returns.shape == (X.shape[0],)
+    assert np.all(np.isnan(portfolio.returns))
+    np.testing.assert_array_equal(portfolio.fitness, np.array([np.nan, np.nan]))
+    portfolio.fitness_measures = [
+        PerfMeasure.MEAN,
+        RiskMeasure.SEMI_DEVIATION,
+        RiskMeasure.MAX_DRAWDOWN,
+    ]
+    np.testing.assert_almost_equal(
+        portfolio.fitness,
+        np.array([np.nan, np.nan, np.nan]),
+    )
+    assert len(portfolio.nonzero_assets_index) == 20
+    assert len(portfolio.nonzero_assets) == 20
+    assert len(portfolio.composition) == 20
+    assert np.isnan(portfolio.composition).all().all()
+
+    contrib = portfolio.contribution(measure=RatioMeasure.SHARPE_RATIO)
+    assert len(contrib) == 20
+    assert np.isnan(contrib).all()
+
+    assert isinstance(portfolio.cumulative_returns_df, pd.Series)
+    assert isinstance(portfolio.drawdowns_df, pd.Series)
+    portfolio.clear()
+    assert portfolio.plot_returns()
+    assert portfolio.plot_cumulative_returns()
+    assert portfolio.plot_drawdowns()
+    assert portfolio.plot_rolling_measure(measure=RatioMeasure.SHARPE_RATIO, window=20)
+    assert isinstance(portfolio.composition, pd.DataFrame)
+    assert portfolio.plot_composition()
+    assert isinstance(portfolio.summary(), pd.Series)
+    assert isinstance(portfolio.summary(formatted=False), pd.Series)
+    assert isinstance(portfolio.summary(), pd.Series)
+
+
+def test_portfolio_magic_methods(X):
+    for ptf_1, ptf_2 in [
+        (FailedPortfolio(X=X), FailedPortfolio(X=X)),
+        (FailedPortfolio(X=X), Portfolio(X=X, weights=rand_weights(n=20))),
+        (Portfolio(X=X, weights=rand_weights(n=20)), FailedPortfolio(X=X)),
+    ]:
+        assert ptf_1.n_observations == X.shape[0]
+        assert ptf_1.n_assets == X.shape[1]
+        ptf = ptf_1 + ptf_2
+        assert isinstance(ptf, FailedPortfolio)
+        ptf = ptf_1 - ptf_2
+
+    for ptf_1, ptf_2 in [
+        (FailedPortfolio(X=X), FailedPortfolio(X=X)),
+        (FailedPortfolio(X=X), Portfolio(X=X, weights=rand_weights(n=20))),
+    ]:
+        assert isinstance(ptf, FailedPortfolio)
+        ptf = -ptf_1
+        assert isinstance(ptf, FailedPortfolio)
+        ptf = ptf_1 * 2.3
+        assert isinstance(ptf, FailedPortfolio)
+        ptf = ptf_1 / 2.3
+        assert isinstance(ptf, FailedPortfolio)
+        ptf = abs(ptf_1)
+        assert isinstance(ptf, FailedPortfolio)
+        ptf = round(ptf_1, 2)
+        assert isinstance(ptf, FailedPortfolio)
+        ptf = ptf_1 // 2
+        assert isinstance(ptf, FailedPortfolio)
+        assert ptf_1 != ptf_1
+        assert ptf_1 != ptf_2
+        assert (ptf_1 > ptf_2) is ptf_1.dominates(ptf_2)
+        assert (ptf_1 < ptf_2) is ptf_2.dominates(ptf_1)
+
+
+def test_portfolio_metrics(portfolio, measure):
+    m = getattr(portfolio, measure.value)
+    assert np.isnan(m)
+
+
+def test_portfolio_metrics2(portfolio):
+    assert np.isnan(portfolio.sric)
+    assert np.isnan(portfolio.skew)
+    assert np.isnan(portfolio.kurtosis)
+    assert np.isnan(portfolio.diversification)
+    assert np.isnan(portfolio.effective_number_assets)
+
+
+def test_portfolio_slots(portfolio):
+    for attr in portfolio._slots():
+        if attr[0] == "_":
+            try:
+                getattr(portfolio, attr[1:])
+            except AttributeError:
+                pass
+        getattr(portfolio, attr)
+
+
+def test_copy(portfolio):
+    with pytest.raises(AttributeError):
+        _ = portfolio._assets_names
+    _ = portfolio.nonzero_assets
+    _ = copy(portfolio)
+
+
+def test_portfolio_cache(portfolio, measure):
+    # time for accessing cached attributes
+    n = int(1e5)
+    ref = timeit.timeit(lambda: portfolio.name, number=n) / n
+    first_access_time = timeit.timeit(
+        lambda: getattr(portfolio, measure.value), number=1
+    )
+    cached_access_time = (
+        timeit.timeit(lambda: getattr(portfolio, measure.value), number=n) / n
+    )
+    assert first_access_time > 10 * cached_access_time
+    assert ref > cached_access_time / 10
+
+
+def test_portfolio_clear_cache(portfolio, measure):
+    if measure.is_ratio:
+        r = measure.linked_risk_measure
+    else:
+        r = measure
+    if r.is_annualized:
+        r = r.non_annualized_measure
+    func = getattr(mt, r.value)
+
+    args = [
+        arg if arg in Portfolio._measure_global_args else f"{r.value}_{arg}"
+        for arg in args_names(func)
+        if arg not in ["biased", "sample_weight"]
+    ]
+    args = [arg for arg in args if arg not in Portfolio._read_only_attrs]
+    # default
+    m = getattr(portfolio, measure.value)
+    for arg in args:
+        if arg == "drawdowns":
+            arg = "compounded"
+        if arg == "compounded":
+            a = not getattr(portfolio, arg)
+        else:
+            a = np.random.uniform(0.2, 1)
+        setattr(portfolio, arg, a)
+        assert getattr(portfolio, arg) == a
+        new_m = getattr(portfolio, str(measure.value))
+        if measure != ExtraRiskMeasure.VALUE_AT_RISK:
+            assert m != new_m
+        if isinstance(measure, RatioMeasure):
+            assert getattr(portfolio, measure.value) == portfolio.mean / new_m
+
+
+def test_portfolio_read_only(portfolio):
+    for attr in Portfolio._read_only_attrs:
+        with pytest.raises(
+            AttributeError,
+            match=f"can't set attribute '{attr}' because it is read-only",
+        ):
+            setattr(portfolio, attr, 0)
+
+
+def test_portfolio_delete_attr(portfolio):
+    with pytest.raises(
+        AttributeError, match="`FailedPortfolio` object has no attribute 'dummy'"
+    ):
+        delattr(portfolio, "dummy")
+
+
+def test_portfolio_rolling_measure(portfolio):
+    for measure in _MEASURES:
+        res = portfolio.rolling_measure(measure=measure, window=30)
+        assert isinstance(res, pd.Series)
+        assert np.isnan(res).all()
+
+
+def test_portfolio_plot_cumulative_returns(portfolio):
+    assert portfolio.plot_cumulative_returns()
+
+    with pytest.raises(ValueError):
+        portfolio.plot_cumulative_returns(log_scale=True)
+
+    portfolio.compounded = True
+    assert portfolio.plot_cumulative_returns()
+    assert portfolio.plot_cumulative_returns(log_scale=True)
+
+
+def test_portfolio_plot_drawdowns(portfolio):
+    assert portfolio.plot_drawdowns()
+    portfolio.compounded = True
+    assert portfolio.plot_drawdowns()
+
+
+def test_portfolio_contribution(portfolio):
+    contribution = portfolio.contribution(measure=RiskMeasure.CVAR, to_df=True)
+    assert isinstance(contribution, pd.DataFrame)
+    assert contribution.shape == (20, 1)
+
+    contribution = portfolio.contribution(measure=RiskMeasure.STANDARD_DEVIATION)
+    assert isinstance(contribution, np.ndarray)
+    assert contribution.shape == (20,)
+
+    assert portfolio.plot_contribution(measure=RiskMeasure.STANDARD_DEVIATION)
+
+
+def test_weights_per_observation(portfolio):
+    df = portfolio.weights_per_observation
+    np.testing.assert_array_equal(df.index.values, portfolio.observations)
+    assert len(df.columns) == 20
+    assert np.isnan(df).all().all()


### PR DESCRIPTION
Fixes #168 


This PR implements the following features:
* add NaN support to risk measures
*  add `FailedPortfolio` for failed optimizations 
*  add fallback mechanism to the optimization classes
* `cross_val_predict` now propagates weights between consecutive folds for sequential CV strategies (e.g., `WalkForward` or  `MultipleRandomizedCV`)

Review should focus on the implementation, documentation and tutorial.


