### PR TITLE
[BUG] maximum diversification no longer fails with negative expected r…

### DIFF
--- a/src/skfolio/optimization/convex/_mean_risk.py
+++ b/src/skfolio/optimization/convex/_mean_risk.py
@@ -1084,7 +1084,7 @@ class MeanRisk(ConvexOptimization):
                     and np.isscalar(self.min_weights)
                     and self.min_weights >= 0
                     and np.max(return_distribution.mu) - self.risk_free_rate <= 0
-               ):
+                ):
                     raise ValueError(
                         "Cannot optimize for Maximum Ratio with your current "
                         "constraints and input. This is because your assets' "


### PR DESCRIPTION
#### Reference Issues

#196 [BUG] MaximumDiversification Fails With Expected Returns <= 0 

#### What does this implement/fix? Explain your changes.

Formerly, MaximumDiversification optimizations would fail if the prior had negative expected returns. This was because MaximumDiversification inherits from MeanRisk which raises an error on negative expected returns. However, since MaximumDiversification overwrites the expected returns, the check no longer made sense. Therefore, we introduced a check in MeanRisk to see if returns have been overwritten before raising an error on negative expected returns.