### PR TITLE
[ENH] Add graph distance estimator for asset adjacency

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -491,6 +491,18 @@ Classes
     distance.CovarianceDistance
     distance.DistanceCorrelation
     distance.MutualInformation
+    distance.GraphDistance
+
+Enum
+----
+.. currentmodule:: skfolio
+
+.. autosummary::
+    :nosignatures:
+    :toctree: generated/
+    :template: enum.rst
+
+    distance.GraphMode
 
 .. _cluster_ref:
 

--- a/docs/user_guide/distance.rst
+++ b/docs/user_guide/distance.rst
@@ -23,6 +23,7 @@ Available estimators are:
     * :class:`CovarianceDistance`
     * :class:`DistanceCorrelation`
     * :class:`MutualInformation`
+    * :class:`GraphDistance`
 
 **Example:**
 
@@ -37,5 +38,29 @@ Available estimators are:
 
     model = PearsonDistance()
     model.fit(X)
+    print(model.codependence_)
+    print(model.distance_)
+
+**Graph adjacency example:**
+
+:class:`GraphDistance` supports asset-to-asset adjacency matrices only. Dependency
+graph mode is not implemented.
+
+.. code-block:: python
+
+    import numpy as np
+
+    from skfolio.distance import GraphDistance
+
+    adjacency_matrix = np.array(
+        [
+            [1.0, 0.8, 0.2],
+            [0.8, 1.0, 0.5],
+            [0.2, 0.5, 1.0],
+        ]
+    )
+
+    model = GraphDistance()
+    model.fit(X.iloc[:, :3], adjacency_matrix=adjacency_matrix)
     print(model.codependence_)
     print(model.distance_)

--- a/src/skfolio/distance/__init__.py
+++ b/src/skfolio/distance/__init__.py
@@ -8,6 +8,8 @@ from skfolio.distance._base import BaseDistance
 from skfolio.distance._distance import (
     CovarianceDistance,
     DistanceCorrelation,
+    GraphDistance,
+    GraphMode,
     KendallDistance,
     MutualInformation,
     NBinsMethod,
@@ -19,6 +21,8 @@ __all__ = [
     "BaseDistance",
     "CovarianceDistance",
     "DistanceCorrelation",
+    "GraphDistance",
+    "GraphMode",
     "KendallDistance",
     "MutualInformation",
     "NBinsMethod",

--- a/src/skfolio/distance/_distance.py
+++ b/src/skfolio/distance/_distance.py
@@ -6,6 +6,8 @@
 
 from __future__ import annotations
 
+from enum import auto
+
 import numpy as np
 import pandas as pd
 import scipy.spatial.distance as scd
@@ -23,7 +25,19 @@ from skfolio.utils.stats import (
     n_bins_freedman,
     n_bins_knuth,
 )
-from skfolio.utils.tools import check_estimator
+from skfolio.utils.tools import AutoEnum, check_estimator
+
+
+class GraphMode(AutoEnum):
+    """Enumeration of Graph Distance modes.
+
+    Parameters
+    ----------
+    ASSET : str
+        Use an asset-to-asset adjacency matrix.
+    """
+
+    ASSET = auto()
 
 
 class PearsonDistance(BaseDistance):
@@ -545,6 +559,100 @@ class MutualInformation(BaseDistance):
             dist[j, i] = dist[i, j]
         self.codependence_ = corr
         self.distance_ = dist
+        return self
+
+
+class GraphDistance(BaseDistance):
+    r"""Graph Distance estimator.
+
+    The codependence is computed from an asset-to-asset adjacency matrix. Weighted
+    adjacency values are min-max normalized into :math:`[0, 1]`, then transformed
+    into a distance matrix using:
+
+    .. math:: distance = \sqrt{1 - codependence}
+
+    Parameters
+    ----------
+    mode : GraphMode, default=GraphMode.ASSET
+        Graph mode. Only :class:`~skfolio.distance.GraphMode.ASSET` is supported.
+
+    Attributes
+    ----------
+    codependence_ : ndarray of shape (n_assets, n_assets)
+        Codependence matrix.
+
+    distance_ : ndarray of shape (n_assets, n_assets)
+        Distance matrix.
+
+    n_features_in_ : int
+        Number of assets seen during `fit`.
+
+    feature_names_in_ : ndarray of shape (`n_features_in_`,)
+        Names of assets seen during `fit`. Defined only when `X`
+        has assets names that are all strings.
+    """
+
+    def __init__(self, mode: GraphMode = GraphMode.ASSET):
+        self.mode = mode
+
+    def fit(
+        self, X: ArrayLike, y=None, adjacency_matrix: ArrayLike | None = None
+    ) -> GraphDistance:
+        """Fit the Graph Distance estimator.
+
+        Parameters
+        ----------
+        X : array-like of shape (n_observations, n_assets)
+            Price returns of the assets.
+
+        y : Ignored
+            Not used, present for API consistency by convention.
+
+        adjacency_matrix : array-like of shape (n_assets, n_assets)
+            Asset-to-asset adjacency matrix, ordered like the assets in `X`.
+
+        Returns
+        -------
+        self : GraphDistance
+            Fitted estimator.
+        """
+        X = skv.validate_data(self, X)
+        if self.mode != GraphMode.ASSET:
+            raise ValueError(f"mode {self.mode} is not supported")
+        if adjacency_matrix is None:
+            raise ValueError("`adjacency_matrix` must be provided")
+        if hasattr(self, "feature_names_in_") and isinstance(
+            adjacency_matrix, pd.DataFrame
+        ):
+            if not np.array_equal(adjacency_matrix.index, self.feature_names_in_):
+                raise ValueError(
+                    "`adjacency_matrix` index must match the assets order in `X`"
+                )
+            if not np.array_equal(adjacency_matrix.columns, self.feature_names_in_):
+                raise ValueError(
+                    "`adjacency_matrix` columns must match the assets order in `X`"
+                )
+
+        adjacency_matrix = skv.check_array(
+            adjacency_matrix, dtype=np.float64, input_name="adjacency_matrix"
+        )
+        n_assets = X.shape[1]
+        if adjacency_matrix.shape != (n_assets, n_assets):
+            raise ValueError(
+                "`adjacency_matrix` must be square with shape "
+                f"({n_assets}, {n_assets}), got {adjacency_matrix.shape}"
+            )
+
+        min_value = adjacency_matrix.min()
+        max_value = adjacency_matrix.max()
+        if min_value == max_value:
+            codependence = np.full_like(adjacency_matrix, np.clip(min_value, 0.0, 1.0))
+        else:
+            codependence = (adjacency_matrix - min_value) / (max_value - min_value)
+        np.fill_diagonal(codependence, 1.0)
+
+        self.codependence_ = codependence
+        self.distance_ = np.sqrt(np.clip(1 - self.codependence_, a_min=0.0, a_max=1.0))
         return self
 
 

--- a/src/skfolio/distance/_distance.py
+++ b/src/skfolio/distance/_distance.py
@@ -590,6 +590,23 @@ class GraphDistance(BaseDistance):
     feature_names_in_ : ndarray of shape (`n_features_in_`,)
         Names of assets seen during `fit`. Defined only when `X`
         has assets names that are all strings.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> from skfolio.distance import GraphDistance
+    >>> X = pd.DataFrame(
+    ...     [[0.01, 0.02, 0.03], [0.02, 0.01, 0.04]],
+    ...     columns=["A", "B", "C"],
+    ... )
+    >>> adjacency = pd.DataFrame(
+    ...     [[1.0, 0.8, 0.2], [0.8, 1.0, 0.5], [0.2, 0.5, 1.0]],
+    ...     index=X.columns,
+    ...     columns=X.columns,
+    ... )
+    >>> model = GraphDistance().fit(X, adjacency_matrix=adjacency)
+    >>> model.distance_.shape
+    (3, 3)
     """
 
     def __init__(self, mode: GraphMode = GraphMode.ASSET):

--- a/tests/test_distance/test_distance.py
+++ b/tests/test_distance/test_distance.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import numpy as np
+import pandas as pd
 import pytest
 from sklearn import config_context
 from sklearn.exceptions import UnsetMetadataPassedError
@@ -10,6 +11,8 @@ from sklearn.exceptions import UnsetMetadataPassedError
 from skfolio.distance import (
     CovarianceDistance,
     DistanceCorrelation,
+    GraphDistance,
+    GraphMode,
     KendallDistance,
     MutualInformation,
     NBinsMethod,
@@ -188,3 +191,76 @@ class TestMutualInformation:
         assert distance.n_bins_method == NBinsMethod.FREEDMAN
         assert distance.n_bins is None
         assert distance.normalize is True
+
+
+class TestGraphDistance:
+    def test_graph_distance(self, X):
+        adjacency_matrix = np.array(
+            [
+                [2.0, 1.0, 0.0],
+                [1.0, 2.0, 0.5],
+                [0.0, 0.5, 2.0],
+            ]
+        )
+        distance = GraphDistance()
+        distance.fit(X.iloc[:, :3], adjacency_matrix=adjacency_matrix)
+
+        expected_codependence = adjacency_matrix / 2.0
+        np.testing.assert_almost_equal(distance.codependence_, expected_codependence)
+        np.testing.assert_almost_equal(
+            distance.distance_, np.sqrt(1 - expected_codependence)
+        )
+        assert distance.codependence_.shape == (3, 3)
+        assert distance.distance_.shape == (3, 3)
+        assert np.all(distance.codependence_ >= 0)
+        assert np.all(distance.codependence_ <= 1)
+        assert np.all(distance.distance_ >= 0)
+        assert np.all(distance.distance_ <= 1)
+
+    def test_default_parameters(self):
+        distance = GraphDistance()
+        assert distance.mode == GraphMode.ASSET
+
+    def test_adjacency_matrix_required(self, X):
+        distance = GraphDistance()
+        with pytest.raises(ValueError, match="adjacency_matrix"):
+            distance.fit(X.iloc[:, :3])
+
+    def test_adjacency_matrix_shape_must_match_assets(self, X):
+        distance = GraphDistance()
+        with pytest.raises(ValueError, match="shape"):
+            distance.fit(X.iloc[:, :3], adjacency_matrix=np.ones((2, 2)))
+
+        with pytest.raises(ValueError, match="shape"):
+            distance.fit(X.iloc[:, :3], adjacency_matrix=np.ones((3, 2)))
+
+    def test_adjacency_matrix_labels_must_match_assets_order(self, X):
+        assets = list(X.columns[:3])
+        adjacency_matrix = pd.DataFrame(
+            np.eye(3), index=assets[::-1], columns=assets[::-1]
+        )
+        distance = GraphDistance()
+        with pytest.raises(ValueError, match="assets order"):
+            distance.fit(X.iloc[:, :3], adjacency_matrix=adjacency_matrix)
+
+    def test_constant_adjacency_matrix(self, X):
+        adjacency_matrix = np.ones((3, 3))
+        distance = GraphDistance()
+        distance.fit(X.iloc[:, :3], adjacency_matrix=adjacency_matrix)
+
+        np.testing.assert_array_equal(distance.codependence_, np.ones((3, 3)))
+        np.testing.assert_array_equal(distance.distance_, np.zeros((3, 3)))
+
+    def test_zero_diagonal_adjacency_matrix(self, X):
+        adjacency_matrix = np.array(
+            [
+                [0.0, 2.0, 1.0],
+                [2.0, 0.0, 0.5],
+                [1.0, 0.5, 0.0],
+            ]
+        )
+        distance = GraphDistance()
+        distance.fit(X.iloc[:, :3], adjacency_matrix=adjacency_matrix)
+
+        np.testing.assert_array_equal(np.diag(distance.codependence_), np.ones(3))
+        np.testing.assert_array_equal(np.diag(distance.distance_), np.zeros(3))

--- a/tests/test_optimization/test_cluster/test_hierarchical/test_hrp.py
+++ b/tests/test_optimization/test_cluster/test_hierarchical/test_hrp.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import numpy as np
+import pandas as pd
 import pytest
 from sklearn import clone, config_context
 
 from skfolio import ExtraRiskMeasure, RiskMeasure
 from skfolio.cluster import HierarchicalClustering, LinkageMethod
+from skfolio.distance import GraphDistance
 from skfolio.moments import EWCovariance, ImpliedCovariance
 from skfolio.optimization import HierarchicalRiskParity
 from skfolio.prior import EmpiricalPrior, EntropyPooling, TimeSeriesFactorModel
@@ -180,6 +182,66 @@ def test_metadata_routing(X_medium, implied_vol_medium):
 
     # noinspection PyUnresolvedReferences
     assert model.prior_estimator_.covariance_estimator_.r2_scores_.shape == (20,)
+
+
+def test_graph_distance_metadata_routing_in_hrp():
+    X = pd.DataFrame(
+        [
+            [0.01, 0.02, 0.03],
+            [0.02, 0.01, 0.04],
+            [0.03, 0.01, 0.02],
+            [0.02, 0.03, 0.01],
+            [0.01, 0.04, 0.02],
+        ],
+        columns=["A", "B", "C"],
+    )
+    adjacency_matrix = pd.DataFrame(
+        [
+            [1.0, 0.8, 0.2],
+            [0.8, 1.0, 0.5],
+            [0.2, 0.5, 1.0],
+        ],
+        index=X.columns,
+        columns=X.columns,
+    )
+
+    with config_context(enable_metadata_routing=True):
+        model = HierarchicalRiskParity(
+            distance_estimator=GraphDistance().set_fit_request(adjacency_matrix=True)
+        )
+        model.fit(X, adjacency_matrix=adjacency_matrix)
+
+    expected_codependence = (adjacency_matrix.to_numpy() - 0.2) / (1.0 - 0.2)
+    np.fill_diagonal(expected_codependence, 1.0)
+    expected_distance = np.sqrt(1 - expected_codependence)
+    np.testing.assert_almost_equal(
+        model.distance_estimator_.distance_, expected_distance
+    )
+
+
+def test_graph_distance_metadata_routing_in_hrp_wrong_labels():
+    X = pd.DataFrame(np.eye(4, 3), columns=["A", "B", "C"])
+    adjacency_matrix = pd.DataFrame(
+        np.eye(3), index=["C", "B", "A"], columns=["C", "B", "A"]
+    )
+
+    with config_context(enable_metadata_routing=True):
+        model = HierarchicalRiskParity(
+            distance_estimator=GraphDistance().set_fit_request(adjacency_matrix=True)
+        )
+        with pytest.raises(ValueError, match="assets order"):
+            model.fit(X, adjacency_matrix=adjacency_matrix)
+
+
+def test_graph_distance_metadata_routing_in_hrp_missing_adjacency():
+    X = pd.DataFrame(np.eye(4, 3), columns=["A", "B", "C"])
+
+    with config_context(enable_metadata_routing=True):
+        model = HierarchicalRiskParity(
+            distance_estimator=GraphDistance().set_fit_request(adjacency_matrix=True)
+        )
+        with pytest.raises(ValueError, match="`adjacency_matrix` must be provided"):
+            model.fit(X)
 
 
 def test_hrp_weight_constraints(X):


### PR DESCRIPTION
#### Reference Issues/PRs

Refs #241.

#### What does this implement/fix? Explain your changes.

Adds `GraphDistance`, a distance estimator that accepts an asset-to-asset adjacency matrix and exposes `codependence_` and `distance_` for clustering-based portfolio optimizers.

This PR intentionally implements only the asset-adjacency slice:

* Supports asset-to-asset adjacency matrices.
* Validates adjacency shape and pandas asset label order.
* Normalizes adjacency values to `[0, 1]`.
* Computes distance from graph codependence.
* Supports HRP integration through sklearn metadata routing.

Dependency graph mode is intentionally not implemented in this PR.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

* [x] Whether `GraphDistance` fits the existing distance estimator API.
* [x] Whether sklearn metadata routing is the right interface for passing `adjacency_matrix`.
* [x] Whether the asset-adjacency-only scope is acceptable for this first PR.
* [x] Whether the distance transformation and validation behavior are appropriate.

#### Did you add any tests for the change?

Yes.

Added:

* Direct `GraphDistance` tests.
* Validation tests for missing adjacency, shape mismatch, and label/order mismatch.
* HRP integration tests proving `adjacency_matrix` is routed to `GraphDistance`.

Validation run:

* `uv run ruff format --check src tests docs`
* `uv run ruff check src tests`
* `uv run --extra dev pytest tests/test_distance/test_distance.py tests/test_optimization/test_cluster/test_hierarchical/test_hrp.py -k "GraphDistance or graph_distance"`
* `git diff --check`

#### Any other comments?

This PR keeps the scope intentionally narrow to avoid mixing asset graph distance with the more complex dependency graph mode discussed in #241.

#### PR checklist

##### For all contributions

* [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].

##### For new estimators

* [x] I've added the estimator to the API reference in `docs/api.rst`.
* [x] I've added one or more illustrative usage examples to the docstring and the `examples` section.
