### PR TITLE
feat(portfolio): add plot_composition_treemap and asset_groups attribute

### DIFF
--- a/src/skfolio/portfolio/_base.py
+++ b/src/skfolio/portfolio/_base.py
@@ -168,6 +168,13 @@ class BasePortfolio:
         The confidence level of the Portfolio EDaR (Entropic Drawdown at Risk).
         The default value is `0.95`.
 
+    asset_groups : dict[str, list[str]], optional
+        A dictionary mapping each asset name to a list of group levels, ordered from
+        the top level to the bottom level (for example
+        ``{"AAPL": ["Equity", "US"]}``). It is used to represent the asset hierarchy,
+        for example in :meth:`~skfolio.portfolio.Portfolio.plot_composition_treemap`.
+        The default (`None`) means no group hierarchy is attached to the Portfolio.
+
     Attributes
     ----------
     n_observations : float
@@ -405,6 +412,7 @@ class BasePortfolio:
         # public
         "tag",
         "name",
+        "asset_groups",
         # public read-only
         "returns",
         "observations",
@@ -506,6 +514,7 @@ class BasePortfolio:
         drawdown_at_risk_beta: float = 0.95,
         cdar_beta: float = 0.95,
         edar_beta: float = 0.95,
+        asset_groups: dict[str, list[str]] | None = None,
     ):
         self._loaded = False
         self._annualized_factor = annualized_factor
@@ -524,6 +533,7 @@ class BasePortfolio:
         self.drawdown_at_risk_beta = drawdown_at_risk_beta
         self.cdar_beta = cdar_beta
         self.edar_beta = edar_beta
+        self.asset_groups = asset_groups
 
         self.name = str(id(self)) if name is None else name
         if fitness_measures is None:

--- a/src/skfolio/portfolio/_portfolio.py
+++ b/src/skfolio/portfolio/_portfolio.py
@@ -15,6 +15,8 @@ from typing import ClassVar
 
 import numpy as np
 import pandas as pd
+import plotly.express as px
+import plotly.graph_objects as go
 
 import skfolio.typing as skt
 from skfolio._constants import _ParamKey
@@ -232,6 +234,14 @@ class Portfolio(BasePortfolio):
         fallback that was attempted, ending with the first `"success"` or the
         last error if all fail. This is set by the optimization estimator and
         propagated to the resulting portfolio.
+
+    asset_groups : dict[str, list[str]], optional
+        A dictionary mapping each asset name to a list of group levels, ordered from
+        the top level to the bottom level (for example
+        ``{"AAPL": ["Equity", "US"]}``). It is used by
+        :meth:`plot_composition_treemap` to nest assets under their groups. It can be
+        forwarded from an optimization estimator through its ``portfolio_params``.
+        The default (`None`) means no group hierarchy is attached to the Portfolio.
 
     Attributes
     ----------
@@ -494,6 +504,7 @@ class Portfolio(BasePortfolio):
         cdar_beta: float = 0.95,
         edar_beta: float = 0.95,
         fallback_chain: list[tuple[str, str]] | None = None,
+        asset_groups: dict[str, list[str]] | None = None,
     ):
         # extract assets names from X
         assets = None
@@ -610,6 +621,7 @@ class Portfolio(BasePortfolio):
             drawdown_at_risk_beta=drawdown_at_risk_beta,
             cdar_beta=cdar_beta,
             edar_beta=edar_beta,
+            asset_groups=asset_groups,
         )
         self._loaded = False
         # We save the original array-like object and not the numpy copy for improved
@@ -971,6 +983,83 @@ class Portfolio(BasePortfolio):
             return self.weights[np.where(self.assets == asset)[0][0]]
         except IndexError:
             raise IndexError("{asset} is not a valid asset name.") from None
+
+    def plot_composition_treemap(
+        self,
+        groups: dict[str, list[str]] | None = None,
+        level_names: list[str] | None = None,
+        title: str = "Portfolio Composition",
+    ) -> go.Figure:
+        """Plot the Portfolio composition as a treemap using the asset groups
+        hierarchy.
+
+        Unlike :meth:`plot_composition`, which gives a flat bar representation, the
+        treemap nests assets under their group levels, making the group structure of
+        the portfolio easy to read.
+
+        Parameters
+        ----------
+        groups : dict[str, list[str]], optional
+            A dictionary mapping each asset name to a list of group levels, ordered
+            from the top level to the bottom level. If not provided, the
+            ``asset_groups`` attribute of the Portfolio is used. If neither is
+            available, the treemap has a single level with all assets directly under
+            the root.
+
+        level_names : list[str], optional
+            The names of the group levels. If not provided, they are named
+            ``Level 1``, ``Level 2``, etc.
+
+        title : str, default="Portfolio Composition"
+            The title of the plot.
+
+        Returns
+        -------
+        plot : Figure
+            Returns the treemap plot Figure object.
+        """
+        if groups is None:
+            groups = self.asset_groups
+
+        df = self.composition
+
+        if groups:
+            if set(groups.keys()) != set(self.assets):
+                raise ValueError(
+                    "The assets in the portfolio and the groups dictionary must be "
+                    "the same."
+                )
+            groups_df = pd.DataFrame(groups).T
+            if level_names is not None:
+                if len(level_names) != len(groups_df.columns):
+                    raise ValueError(
+                        "The number of level names must match the number of levels "
+                        "in the groups."
+                    )
+                groups_df.columns = level_names
+            else:
+                groups_df.columns = [
+                    f"Level {i + 1}" for i in range(len(groups_df.columns))
+                ]
+            composition_with_groups = df.join(groups_df).reset_index()
+            group_names = list(groups_df.columns)
+        else:
+            composition_with_groups = df.reset_index()
+            group_names = []
+
+        value_name = df.columns[0]
+        path = [px.Constant("all")]
+        path.extend(group_names)
+        path.append("asset")
+
+        fig = px.treemap(
+            composition_with_groups,
+            path=path,
+            values=value_name,
+            title=title,
+        )
+        fig.update_traces(textinfo="label+value", textfont_size=14)
+        return fig
 
 
 def _get_risk(

--- a/tests/test_portfolio/test_portfolio.py
+++ b/tests/test_portfolio/test_portfolio.py
@@ -568,3 +568,71 @@ def test_portfolio_nan_handling(X, weights):
     portfolio_nan = Portfolio(X=X_nan_zero_only, weights=weights)
     portfolio_ref = Portfolio(X=X, weights=weights)
     np.testing.assert_array_almost_equal(portfolio_nan.returns, portfolio_ref.returns)
+
+
+def _small_portfolio(with_groups: bool = True) -> Portfolio:
+    rng = np.random.default_rng(42)
+    X_small = pd.DataFrame(
+        rng.normal(0.001, 0.02, (60, 4)),
+        columns=["asset_a", "asset_b", "asset_c", "asset_d"],
+    )
+    weights = np.array([0.4, 0.3, 0.2, 0.1])
+    groups = None
+    if with_groups:
+        groups = {
+            "asset_a": ["Equity", "US"],
+            "asset_b": ["Equity", "EU"],
+            "asset_c": ["Bond", "US"],
+            "asset_d": ["Bond", "EU"],
+        }
+    return Portfolio(X=X_small, weights=weights, asset_groups=groups)
+
+
+def test_asset_groups_attribute():
+    ptf = _small_portfolio()
+    assert ptf.asset_groups == {
+        "asset_a": ["Equity", "US"],
+        "asset_b": ["Equity", "EU"],
+        "asset_c": ["Bond", "US"],
+        "asset_d": ["Bond", "EU"],
+    }
+    # default is None
+    assert (
+        Portfolio(
+            X=pd.DataFrame(np.ones((5, 2)), columns=["a", "b"]),
+            weights=np.array([0.5, 0.5]),
+        ).asset_groups
+        is None
+    )
+    # survives pickling (stored in __slots__ and __reduce__)
+    assert pickle.loads(pickle.dumps(ptf)).asset_groups == ptf.asset_groups
+
+
+def test_plot_composition_treemap():
+    import plotly.graph_objects as go
+
+    ptf = _small_portfolio()
+    # uses the asset_groups attribute by default
+    fig = ptf.plot_composition_treemap()
+    assert isinstance(fig, go.Figure)
+    # explicit level names
+    fig = ptf.plot_composition_treemap(level_names=["Class", "Region"])
+    assert isinstance(fig, go.Figure)
+    # explicit groups override the attribute
+    fig = ptf.plot_composition_treemap(
+        groups={a: ["G"] for a in ptf.assets}, level_names=["Group"]
+    )
+    assert isinstance(fig, go.Figure)
+    # portfolio without groups still renders a flat treemap
+    assert isinstance(_small_portfolio(with_groups=False).plot_composition_treemap(),
+                      go.Figure)
+
+
+def test_plot_composition_treemap_errors():
+    ptf = _small_portfolio()
+    # groups keys must match the portfolio assets
+    with pytest.raises(ValueError, match="must be the same"):
+        ptf.plot_composition_treemap(groups={"asset_a": ["G"]})
+    # level_names length must match the number of levels
+    with pytest.raises(ValueError, match="number of level names"):
+        ptf.plot_composition_treemap(level_names=["only_one"])


### PR DESCRIPTION
## Summary

Closes #163. Adds a treemap visualization of portfolio weights that nests assets under their group hierarchy, complementing the flat `plot_composition` bar chart.

Implements the design agreed in the issue:

1. **`asset_groups` attribute on `BasePortfolio`** — a `dict[str, list[str]]` mapping each asset to its group levels (top → bottom, e.g. `{"AAPL": ["Equity", "Tech"]}`). Added to `__slots__`, the constructor, and the docstrings; it is `None` by default and round-trips through pickling. As you noted in the issue, this attribute is the natural home for group metadata that future methods can reuse.

2. **`Portfolio.plot_composition_treemap(...)`** — a method on `Portfolio` (not `BasePortfolio`, since a treemap is not meaningful for `MultiPeriodPortfolio`). It uses the `asset_groups` attribute by default, accepts an explicit `groups` override plus optional `level_names`/`title`, validates that the group keys match the portfolio assets, and falls back to a flat treemap when no groups are available.

Forwarding from an optimization estimator already works through `portfolio_params`, so no change to the optimization layer is needed:

```python
model = MeanRisk(portfolio_params={"asset_groups": groups})
ptf = model.fit(X).predict(X)
ptf.plot_composition_treemap(level_names=["Asset Class", "Sector"])
```

## Visual result

The treemap nests each asset under its sector and asset class, with the weight shown per tile (rendered from a `MeanRisk` portfolio via the snippet above):

_(screenshot attached in the PR — Equity → Tech / Financials / Energy → individual assets with weights)_

## Notes

- **Automatic forwarding of the optimizer's `groups` constraint parameter** to `asset_groups` was intentionally left out: the optimizer `groups` (constraint groups) and the portfolio `asset_groups` (per-asset level hierarchy) use different shapes, so mapping one to the other is a design decision I'd rather confirm with you than guess. Users can already forward explicit `asset_groups` via `portfolio_params` as shown above. Happy to add auto-forwarding in this PR or a follow-up once we agree on the mapping.

## Testing

- Added `test_asset_groups_attribute` (storage, `None` default, pickle round-trip) and `test_plot_composition_treemap` / `test_plot_composition_treemap_errors` (attribute default, explicit-groups override, `level_names`, no-groups flat treemap, and both validation errors).
- Full `tests/test_portfolio/test_portfolio.py` passes (218 passed) — no regression from the `__slots__`/constructor change.
- `ruff check` and `ruff format --check` clean on all changed files.
