### PR TITLE
[DOC] Improve add_constraints docstring

### DIFF
--- a/src/skfolio/optimization/convex/_base.py
+++ b/src/skfolio/optimization/convex/_base.py
@@ -395,10 +395,21 @@ class ConvexOptimization(BaseOptimization, ABC):
         It is a function that must take as argument the weights `w` and returns a
         CVXPY expression.
 
-    add_constraints : Callable[[cp.Variable], cp.Expression|list[cp.Expression]], optional
+    add_constraints : Callable[[cp.Variable], cp.Expression | list[cp.Expression]] | Callable[[cp.Variable, ConvexOptimization], cp.Expression | list[cp.Expression]], optional
         Add a custom constraint or a list of constraints to the existing constraints.
-        It is a function that must take as argument the weights `w` and returns a
-        CVXPY expression or a list of CVXPY expressions.
+        The callable must accept the weights as its first argument. It can optionally
+        accept the estimator instance as its second argument, allowing access to the
+        estimator's attributes. It must return a CVXPY expression or a list of CVXPY
+        expressions.
+
+        For example, the estimator instance can provide its `budget` attribute:
+
+        >>> from skfolio.optimization import MeanRisk
+        >>> def custom_constraints(weights, estimator):
+        ...     return [weights >= estimator.budget / 20]
+        >>> model = MeanRisk(add_constraints=custom_constraints)
+
+        The custom constraint is evaluated when `fit` is called.
 
     overwrite_expected_return : Callable[[cp.Variable], cp.Expression], optional
         Overwrite the expected return :math:`\mu \cdot w` with a custom expression.

--- a/src/skfolio/optimization/convex/_benchmark_tracker.py
+++ b/src/skfolio/optimization/convex/_benchmark_tracker.py
@@ -162,9 +162,21 @@ class BenchmarkTracker(MeanRisk):
         Add a custom objective to the existing objective expression.
         See :class:`~skfolio.optimization.MeanRisk` for details.
 
-    add_constraints : Callable[[cp.Variable], cp.Expression|list[cp.Expression]], optional
-        Add a custom constraint or a list of constraints.
-        See :class:`~skfolio.optimization.MeanRisk` for details.
+    add_constraints : Callable[[cp.Variable], cp.Expression | list[cp.Expression]] | Callable[[cp.Variable, ConvexOptimization], cp.Expression | list[cp.Expression]], optional
+        Add a custom constraint or a list of constraints to the existing constraints.
+        The callable must accept the weights as its first argument. It can optionally
+        accept the estimator instance as its second argument, allowing access to the
+        estimator's attributes. It must return a CVXPY expression or a list of CVXPY
+        expressions.
+
+        For example, the estimator instance can provide its `budget` attribute:
+
+        >>> from skfolio.optimization import MeanRisk
+        >>> def custom_constraints(weights, estimator):
+        ...     return [weights >= estimator.budget / 20]
+        >>> model = MeanRisk(add_constraints=custom_constraints)
+
+        The custom constraint is evaluated when `fit` is called.
 
     portfolio_params : dict, optional
         Portfolio parameters.

--- a/src/skfolio/optimization/convex/_distributionally_robust.py
+++ b/src/skfolio/optimization/convex/_distributionally_robust.py
@@ -167,10 +167,21 @@ class DistributionallyRobustCVaR(ConvexOptimization):
         Risk-free interest rate.
         The default value is `0.0`.
 
-    add_constraints : Callable[[cp.Variable], cp.Expression|list[cp.Expression]], optional
+    add_constraints : Callable[[cp.Variable], cp.Expression | list[cp.Expression]] | Callable[[cp.Variable, ConvexOptimization], cp.Expression | list[cp.Expression]], optional
         Add a custom constraint or a list of constraints to the existing constraints.
-        It is a function that must take as argument the weights `w` and returns a
-        CVXPY expression or a list of CVXPY expressions.
+        The callable must accept the weights as its first argument. It can optionally
+        accept the estimator instance as its second argument, allowing access to the
+        estimator's attributes. It must return a CVXPY expression or a list of CVXPY
+        expressions.
+
+        For example, the estimator instance can provide its `budget` attribute:
+
+        >>> from skfolio.optimization import MeanRisk
+        >>> def custom_constraints(weights, estimator):
+        ...     return [weights >= estimator.budget / 20]
+        >>> model = MeanRisk(add_constraints=custom_constraints)
+
+        The custom constraint is evaluated when `fit` is called.
 
     overwrite_expected_return : Callable[[cp.Variable], cp.Expression], optional
         Overwrite the expected return :math:`\mu \cdot w` with a custom expression.

--- a/src/skfolio/optimization/convex/_maximum_diversification.py
+++ b/src/skfolio/optimization/convex/_maximum_diversification.py
@@ -295,10 +295,21 @@ class MaximumDiversification(MeanRisk):
         It is a function that must take as argument the weights `w` and returns a
         CVXPY expression.
 
-    add_constraints : Callable[[cp.Variable], cp.Expression|list[cp.Expression]], optional
+    add_constraints : Callable[[cp.Variable], cp.Expression | list[cp.Expression]] | Callable[[cp.Variable, ConvexOptimization], cp.Expression | list[cp.Expression]], optional
         Add a custom constraint or a list of constraints to the existing constraints.
-        It is a function that must take as argument the weights `w` and returns a
-        CVPXY expression or a list of CVPXY expressions.
+        The callable must accept the weights as its first argument. It can optionally
+        accept the estimator instance as its second argument, allowing access to the
+        estimator's attributes. It must return a CVXPY expression or a list of CVXPY
+        expressions.
+
+        For example, the estimator instance can provide its `budget` attribute:
+
+        >>> from skfolio.optimization import MeanRisk
+        >>> def custom_constraints(weights, estimator):
+        ...     return [weights >= estimator.budget / 20]
+        >>> model = MeanRisk(add_constraints=custom_constraints)
+
+        The custom constraint is evaluated when `fit` is called.
 
     solver : str, default="CLARABEL"
         The solver to use. The default is "CLARABEL" which is written in Rust and has

--- a/src/skfolio/optimization/convex/_mean_risk.py
+++ b/src/skfolio/optimization/convex/_mean_risk.py
@@ -529,10 +529,21 @@ class MeanRisk(ConvexOptimization):
         It is a function that must take as argument the weights `w` and returns a
         CVXPY expression.
 
-    add_constraints : Callable[[cp.Variable], cp.Expression|list[cp.Expression]], optional
+    add_constraints : Callable[[cp.Variable], cp.Expression | list[cp.Expression]] | Callable[[cp.Variable, ConvexOptimization], cp.Expression | list[cp.Expression]], optional
         Add a custom constraint or a list of constraints to the existing constraints.
-        It is a function that must take as argument the weights `w` and returns a
-        CVXPY expression or a list of CVXPY expressions.
+        The callable must accept the weights as its first argument. It can optionally
+        accept the estimator instance as its second argument, allowing access to the
+        estimator's attributes. It must return a CVXPY expression or a list of CVXPY
+        expressions.
+
+        For example, the estimator instance can provide its `budget` attribute:
+
+        >>> from skfolio.optimization import MeanRisk
+        >>> def custom_constraints(weights, estimator):
+        ...     return [weights >= estimator.budget / 20]
+        >>> model = MeanRisk(add_constraints=custom_constraints)
+
+        The custom constraint is evaluated when `fit` is called.
 
     overwrite_expected_return : Callable[[cp.Variable], cp.Expression], optional
         Overwrite the expected return :math:`\mu \cdot w` with a custom expression.

--- a/src/skfolio/optimization/convex/_risk_budgeting.py
+++ b/src/skfolio/optimization/convex/_risk_budgeting.py
@@ -297,10 +297,21 @@ class RiskBudgeting(ConvexOptimization):
         It is a function that must take as argument the weights `w` and returns a
         CVXPY expression.
 
-    add_constraints : Callable[[cp.Variable], cp.Expression|list[cp.Expression]], optional
+    add_constraints : Callable[[cp.Variable], cp.Expression | list[cp.Expression]] | Callable[[cp.Variable, ConvexOptimization], cp.Expression | list[cp.Expression]], optional
         Add a custom constraint or a list of constraints to the existing constraints.
-        It is a function that must take as argument the weights `w` and returns a
-        CVXPY expression or a list of CVXPY expressions.
+        The callable must accept the weights as its first argument. It can optionally
+        accept the estimator instance as its second argument, allowing access to the
+        estimator's attributes. It must return a CVXPY expression or a list of CVXPY
+        expressions.
+
+        For example, the estimator instance can provide its `budget` attribute:
+
+        >>> from skfolio.optimization import MeanRisk
+        >>> def custom_constraints(weights, estimator):
+        ...     return [weights >= estimator.budget / 20]
+        >>> model = MeanRisk(add_constraints=custom_constraints)
+
+        The custom constraint is evaluated when `fit` is called.
 
     overwrite_expected_return : Callable[[cp.Variable], cp.Expression], optional
         Overwrite the expected return :math:`\mu \cdot w` with a custom expression.


### PR DESCRIPTION
## Description

Document both supported `add_constraints` callback signatures across the six public convex-optimization APIs:

- `callable(weights)`
- `callable(weights, estimator)`

Each docstring now explains the estimator argument and includes the `estimator.budget / 20` example from the issue.

Closes #134

## Validation

- Ruff check and format check pass
- numpydoc validation passes for all six affected public classes
- the documented callback was executed through `MeanRisk.fit` and received the estimator instance (`min_weight == 0.05`)
- relevant cache test passes
- `git diff --check` passes
- focused Sphinx build reached the affected API docs; `-W` only reported pre-existing warnings outside the changed docstrings under Python 3.14