### PR TITLE
[DOC] Add GraphicalLassoCV covariance example

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -606,6 +606,7 @@ TUTORIAL_ORDER = {
         "plot_15_mip_cardinality_constraints.py",
         "plot_16_mip_threshold_constraints.py",
         "plot_17_failure_and_fallbacks.py",
+        "plot_18_graphical_lasso.py",
     ),
     "factor_models": (
         "plot_characteristics_factor_model.py",

--- a/examples/mean_risk/plot_18_graphical_lasso.py
+++ b/examples/mean_risk/plot_18_graphical_lasso.py
@@ -1,0 +1,190 @@
+r"""Graphical Lasso Covariance Estimation.
+==========================================
+
+This tutorial shows how to use
+:class:`~skfolio.moments.GraphicalLassoCV` as the covariance estimator of a
+:class:`~skfolio.optimization.MeanRisk` optimization.
+
+The empirical covariance matrix can be unstable when the number of assets is large
+relative to the number of observations. Graphical Lasso [1]_ regularizes the inverse
+covariance, also called the precision matrix, by solving an optimization problem of
+the form:
+
+.. math::
+
+    \underset{\Theta \succ 0}{\operatorname{minimize}}\;
+    \operatorname{tr}(S\Theta) - \log\det(\Theta)
+    + \alpha \lVert\Theta\rVert_1,
+
+where :math:`S` is the empirical covariance and :math:`\Theta` is the precision
+matrix. The L1 penalty encourages zeros in :math:`\Theta`. Under a multivariate
+Gaussian model, a zero off-diagonal entry means that two assets are conditionally
+independent given all the other assets.
+
+:class:`~skfolio.moments.GraphicalLassoCV` selects the regularization parameter
+:math:`\alpha` by cross-validation and exposes both the regularized covariance in
+`covariance_` and the sparse inverse covariance in `precision_`.
+"""
+
+# %%
+# Data
+# ====
+# We load the S&P 500 :ref:`dataset <datasets>`, convert prices to linear returns, and
+# split the observations chronologically to avoid :ref:`data leakage <data_leakage>`.
+
+import numpy as np
+import pandas as pd
+import plotly.express as px
+from plotly.io import show
+from sklearn.model_selection import TimeSeriesSplit, train_test_split
+
+from skfolio import Population
+from skfolio.datasets import load_sp500_dataset
+from skfolio.moments import EmpiricalCovariance, GraphicalLassoCV, LedoitWolf
+from skfolio.optimization import MeanRisk
+from skfolio.preprocessing import prices_to_returns
+from skfolio.prior import EmpiricalPrior
+
+prices = load_sp500_dataset()
+X = prices_to_returns(prices)
+X_train, X_test = train_test_split(X, test_size=0.33, shuffle=False)
+
+# %%
+# Sparse conditional-dependence structure
+# =======================================
+# We use a chronological inner cross-validation to select `alpha`. An explicit,
+# compact grid keeps the tutorial fast and reproducible. Larger research workflows
+# can use a wider grid or the estimator's iterative grid refinement.
+
+graphical_lasso = GraphicalLassoCV(
+    alphas=[3e-6, 1e-5, 3e-5],
+    cv=TimeSeriesSplit(n_splits=5),
+    max_iter=300,
+)
+graphical_lasso.fit(X_train)
+
+precision = graphical_lasso.precision_
+off_diagonal = ~np.eye(precision.shape[0], dtype=bool)
+sparsity = np.mean(np.isclose(precision[off_diagonal], 0.0))
+
+print(f"Selected alpha: {graphical_lasso.alpha_:.2e}")
+print(f"Zero off-diagonal precision entries: {sparsity:.1%}")
+
+# %%
+# The partial correlation between assets :math:`i` and :math:`j`, conditional on all
+# other assets, is obtained from the precision matrix as
+#
+# .. math::
+#
+#     \rho_{ij \mid -ij} =
+#     -\frac{\Theta_{ij}}{\sqrt{\Theta_{ii}\Theta_{jj}}}.
+#
+# The heatmap makes the sparse conditional-dependence structure easier to interpret
+# than the raw precision matrix.
+
+precision_scale = np.sqrt(np.outer(np.diag(precision), np.diag(precision)))
+partial_correlation = -precision / precision_scale
+np.fill_diagonal(partial_correlation, 1.0)
+partial_correlation = pd.DataFrame(
+    partial_correlation,
+    index=X_train.columns,
+    columns=X_train.columns,
+)
+
+fig = px.imshow(
+    partial_correlation,
+    zmin=-1,
+    zmax=1,
+    color_continuous_scale="RdBu_r",
+    title="Graphical Lasso Partial Correlations",
+)
+show(fig)
+
+# %%
+# Sparse precision versus conic optimization
+# ===========================================
+# :class:`~skfolio.optimization.MeanRisk` uses the estimator's `covariance_` to define
+# portfolio variance. At the exact graphical-lasso optimum, the covariance and
+# precision are inverses. The fitted numerical pair is nevertheless not an API
+# guarantee of exact inversion, so skfolio does not silently replace `covariance_` with
+# an inverse reconstructed from `precision_`. The precision is useful for statistical
+# interpretation, but its zeros do not generally make `covariance_` sparse. Moreover,
+# a Cholesky factor can introduce fill-in even when the precision itself is sparse.
+# skfolio therefore preserves the covariance-estimation benefit of Graphical Lasso,
+# while representing the risk with a Cholesky factor of `covariance_` in its
+# second-order cone program.
+#
+# The following diagnostic compares lower-triangular non-zero counts. It is only a
+# matrix-structure diagnostic: it does not imply a reduction in CVXPY cone dimensions,
+# solver variables, or solve time.
+
+covariance_cholesky = np.linalg.cholesky(graphical_lasso.covariance_)
+precision_cholesky = np.linalg.cholesky(precision)
+print(
+    "Lower-triangular non-zeros "
+    f"(precision / precision Cholesky / covariance Cholesky): "
+    f"{np.count_nonzero(np.tril(precision))} / "
+    f"{np.count_nonzero(precision_cholesky)} / "
+    f"{np.count_nonzero(covariance_cholesky)}"
+)
+
+# We compare Graphical Lasso with empirical covariance and Ledoit-Wolf shrinkage. All
+# three models solve the same long-only minimum-variance problem.
+
+models = {
+    "Empirical": MeanRisk(
+        prior_estimator=EmpiricalPrior(covariance_estimator=EmpiricalCovariance()),
+        portfolio_params=dict(name="Empirical"),
+    ),
+    "Ledoit-Wolf": MeanRisk(
+        prior_estimator=EmpiricalPrior(covariance_estimator=LedoitWolf()),
+        portfolio_params=dict(name="Ledoit-Wolf"),
+    ),
+    "Graphical Lasso CV": MeanRisk(
+        prior_estimator=EmpiricalPrior(covariance_estimator=graphical_lasso),
+        portfolio_params=dict(name="Graphical Lasso CV"),
+    ),
+}
+
+portfolios = []
+rows = []
+for name, model in models.items():
+    model.fit(X_train)
+    portfolio = model.predict(X_test)
+    portfolios.append(portfolio)
+
+    fitted_covariance = model.prior_estimator_.covariance_estimator_
+    rows.append(
+        {
+            "Estimator": name,
+            "Covariance test score": fitted_covariance.score(X_test),
+            "Annualized variance": portfolio.annualized_variance,
+            "Annualized Sharpe ratio": portfolio.annualized_sharpe_ratio,
+            "Effective number of assets": portfolio.effective_number_assets,
+        }
+    )
+
+comparison = pd.DataFrame(rows).set_index("Estimator")
+print(comparison)
+
+# %%
+# `BaseCovariance.score` is the held-out Gaussian log-likelihood, for which higher is
+# better. Portfolio measures evaluate a different downstream objective. Consequently,
+# the covariance estimator with the best likelihood need not produce the portfolio
+# with the lowest realized variance on one historical split.
+#
+# We inspect the allocations and cumulative returns without treating this single split
+# as evidence that one estimator is universally superior.
+
+population = Population(portfolios)
+population.plot_composition()
+
+# %%
+fig = population.plot_cumulative_returns()
+show(fig)
+
+# %%
+# References
+# ==========
+# .. [1] "Sparse inverse covariance estimation with the graphical lasso",
+#         Jerome Friedman, Trevor Hastie, and Robert Tibshirani (2008)


### PR DESCRIPTION
#### Reference Issues/PRs

Fixes #63.

#### What does this implement/fix? Explain your changes.

This PR adds a `GraphicalLassoCV` tutorial for mean-risk portfolio optimization.

`GraphicalLassoCV` estimates both a regularized covariance matrix (`covariance_`) and a sparse precision matrix (`precision_`). The example demonstrates how the estimator is used in skfolio, visualizes the resulting partial correlations, and compares it with empirical covariance and Ledoit-Wolf shrinkage in long-only minimum-variance optimization.

The investigation also clarifies the distinction between statistical and computational sparsity:

* A zero off-diagonal precision entry represents conditional independence under the Gaussian graphical-model interpretation.
* Sparse precision does not generally imply sparse covariance.
* Cholesky factorization may introduce fill-in.
* skfolio currently defines portfolio risk from `covariance_` and represents variance using its covariance factor in the SOCP formulation.
* Although covariance and precision are inverses at the exact graphical-lasso optimum, the fitted API does not guarantee that the returned numerical matrices are exact inverses. Replacing `covariance_` with a matrix implied by `precision_` could therefore silently alter the portfolio optimization problem.

The example reports structural sparsity diagnostics only and intentionally makes no end-to-end performance claim.

#### Does your contribution introduce a new dependency? If yes, which one?

No.

#### What should a reviewer concentrate their feedback on?

* Whether the example correctly explains the interpretation of `precision_`.
* Whether the distinction between statistical sparsity and SOCP computational sparsity is sufficiently clear.
* Whether retaining `covariance_` as the authoritative portfolio-risk representation is the appropriate conclusion for the current API.

#### Did you add any tests for the change?

No production behavior changes. The example was executed end-to-end and the focused `GraphicalLassoCV` and `EmpiricalPrior` tests were run.

#### Any other comments?

I also investigated whether the sparse precision matrix could be exploited directly in the conic formulation.

If an exact precision matrix satisfies `Θ = Σ⁻¹` and admits a factorization `Θ = C Cᵀ`, portfolio risk can be represented exactly by introducing an auxiliary variable `y` satisfying `C y = w`, so that `‖y‖₂² = wᵀΣw`.

Experiments indicate that this representation can substantially reduce the conic problem size when the model starts from a genuinely exact sparse precision matrix.

However, this is not appropriate as a hidden optimization path for the current `GraphicalLassoCV` wrapper because `precision_` is not an explicit exact-inverse contract for the authoritative `covariance_`.

A possible future enhancement would therefore be an explicit precision-authoritative estimator or exact precision-factor representation, rather than special-casing `GraphicalLassoCV`.

That design is intentionally outside the scope of this PR.

#### PR checklist

##### For all contributions

* [x] The PR title starts with either [ENH], [MNT], [DOC], or [BUG].

##### For new estimators

Not applicable.
